### PR TITLE
Implemented and tested Party Randomization

### DIFF
--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -220,6 +220,9 @@
             <setting name="TextSettingsValue" serializeAs="String">
                 <value>Default</value>
             </setting>
+            <setting name="RandomizePartyMembers" serializeAs="String">
+                <value>False</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/Forms/OtherForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/OtherForm.Designer.cs
@@ -34,6 +34,7 @@
             this.cbPolymorph = new System.Windows.Forms.CheckBox();
             this.cbNameGen = new System.Windows.Forms.CheckBox();
             this.cbPazaak = new System.Windows.Forms.CheckBox();
+            this.cbPartyRando = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // label1
@@ -113,12 +114,26 @@
             this.cbPazaak.UseVisualStyleBackColor = true;
             this.cbPazaak.CheckedChanged += new System.EventHandler(this.cbPazaak_CheckedChanged);
             // 
+            // cbPartyRando
+            // 
+            this.cbPartyRando.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.cbPartyRando.Location = new System.Drawing.Point(180, 270);
+            this.cbPartyRando.Name = "cbPartyRando";
+            this.cbPartyRando.Size = new System.Drawing.Size(120, 110);
+            this.cbPartyRando.TabIndex = 54;
+            this.cbPartyRando.Text = "Randomize Party Members - This entirely morphs each party member into a different" +
+    " creature, wth different stats and equipment.\r\n";
+            this.cbPartyRando.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.cbPartyRando.UseVisualStyleBackColor = true;
+            this.cbPartyRando.CheckedChanged += new System.EventHandler(this.cbPartyRando_CheckedChanged);
+            // 
             // OtherForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.ClientSize = new System.Drawing.Size(365, 401);
+            this.Controls.Add(this.cbPartyRando);
             this.Controls.Add(this.cbPazaak);
             this.Controls.Add(this.cbNameGen);
             this.Controls.Add(this.cbPolymorph);
@@ -145,5 +160,6 @@
         private System.Windows.Forms.CheckBox cbPolymorph;
         private System.Windows.Forms.CheckBox cbNameGen;
         private System.Windows.Forms.CheckBox cbPazaak;
+        private System.Windows.Forms.CheckBox cbPartyRando;
     }
 }

--- a/kotor Randomizer 2/Forms/OtherForm.cs
+++ b/kotor Randomizer 2/Forms/OtherForm.cs
@@ -22,6 +22,7 @@ namespace kotor_Randomizer_2
             cbNameGen.Checked = Properties.Settings.Default.RandomizeNameGen;
             cbPolymorph.Checked = Properties.Settings.Default.PolymorphMode;
             cbPazaak.Checked = Properties.Settings.Default.RandomizePazaakDecks;
+            cbPartyRando.Checked = Properties.Settings.Default.RandomizePartyMembers;
         }
 
         #region private properties
@@ -128,6 +129,11 @@ namespace kotor_Randomizer_2
         private void cbPazaak_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.RandomizePazaakDecks = cbPazaak.Checked;
+        }
+
+        private void cbPartyRando_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.RandomizePartyMembers = cbPartyRando.Checked;
         }
 
         #endregion

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -818,5 +818,17 @@ namespace kotor_Randomizer_2.Properties {
                 this["TextSettingsValue"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RandomizePartyMembers {
+            get {
+                return ((bool)(this["RandomizePartyMembers"]));
+            }
+            set {
+                this["RandomizePartyMembers"] = value;
+            }
+        }
     }
 }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -204,5 +204,8 @@
     <Setting Name="TextSettingsValue" Type="kotor_Randomizer_2.TextSettings" Scope="User">
       <Value Profile="(Default)">Default</Value>
     </Setting>
+    <Setting Name="RandomizePartyMembers" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Randomization/OtherRando.cs
+++ b/kotor Randomizer 2/Randomization/OtherRando.cs
@@ -10,8 +10,22 @@ namespace kotor_Randomizer_2
 {
     public static class OtherRando
     {
-        public static readonly string PAZAAKDECKS_RESREF = "pazaakdecks";
-        public static readonly string DECKNAME_COLUMN = "deckname";
+        private const string PAZAAKDECKS_RESREF = "pazaakdecks";
+        private const string DECKNAME_COLUMN = "deckname";
+
+        //List of Tuples matching each party member's various identifying data (item1 : dialogue file, item2 : file name/ResRef, item3 : Scripting Tag)
+        private static readonly List<Tuple<string, string, string>> Party_IDs = new List<Tuple<string, string, string>>()
+        {
+            new Tuple<string, string, string>("k_hbas_dialog", "p_bastilla", "Bastila"),
+            new Tuple<string, string, string>("k_hcan_dialog", "p_cand", "Cand"),
+            new Tuple<string, string, string>("k_hcar_dialog", "p_carth", "Carth"),
+            new Tuple<string, string, string>("k_hhkd_dialog", "p_hk47", "HK47"),
+            new Tuple<string, string, string>("k_hjol_dialog", "p_jolee", "Jolee"),
+            new Tuple<string, string, string>("k_hjuh_dialog", "p_juhani", "Juhani"),
+            new Tuple<string, string, string>("k_hmis_dialog", "p_mission", "Mission"),
+            new Tuple<string, string, string>("k_htmd_dialog", "p_t3m4", "T3M4"),
+            new Tuple<string, string, string>("k_hzaa_dialog", "p_zaalbar", "Zaalbar"),
+        };
 
         public static void other_rando(KPaths paths)
         {
@@ -116,6 +130,52 @@ namespace kotor_Randomizer_2
                 }
 
                 t.WriteToDirectory(paths.Override);
+            }
+
+            //Party Rando
+            if (Properties.Settings.Default.RandomizePartyMembers) //ADD SETTING
+            {
+                BIF b = new BIF(paths.data + "templates.bif");
+                KEY k = new KEY(paths.chitin_backup);
+                b.AttachKey(k, "data\\templates.bif");
+
+                foreach (var ID in Party_IDs)
+                {
+                    //Find a creature that isn't the party member
+                    var resource = b.VariableResourceTable.Where(x => x.ResRef != ID.Item2 && x.ResourceType == ResourceType.UTC).ToList()[Randomize.Rng.Next(155)];
+
+                    GFF g = new GFF(resource.EntryData);
+
+                    //Turns Creature File into a playable companion replacing the current party member
+                    (g.Top_Level.Fields.Where(x => x.Label == "Conversation").FirstOrDefault() as GFF.ResRef).Reference = ID.Item1;
+                    (g.Top_Level.Fields.Where(x => x.Label == "Tag").FirstOrDefault() as GFF.CExoString).CEString = ID.Item3;
+                    (g.Top_Level.Fields.Where(x => x.Label == "TemplateResRef").FirstOrDefault() as GFF.ResRef).Reference = ID.Item2;
+                    (g.Top_Level.Fields.Where(x => x.Label == "NoPermDeath").FirstOrDefault() as GFF.BYTE).value = 1;
+                    (g.Top_Level.Fields.Where(x => x.Label == "FactionID").FirstOrDefault() as GFF.WORD).value = 2;
+
+                    //Henchmen Script suite
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptHeartbeat").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_heartbt01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptOnNotice").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_percept01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptSpellAt").FirstOrDefault() as GFF.ResRef).Reference = "";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptAttacked").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_attacked01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptDamaged").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_damage01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptDisturbed").FirstOrDefault() as GFF.ResRef).Reference = "";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptEndRound").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_combend01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptEndDialogu").FirstOrDefault() as GFF.ResRef).Reference = "";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptDialogue").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_dialogue01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptSpawn").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_spawn01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptRested").FirstOrDefault() as GFF.ResRef).Reference = "";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptDeath").FirstOrDefault() as GFF.ResRef).Reference = "";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptOnBlocked").FirstOrDefault() as GFF.ResRef).Reference = "k_hen_blocked01";
+                    (g.Top_Level.Fields.Where(x => x.Label == "ScriptUserDefine").FirstOrDefault() as GFF.ResRef).Reference = "";
+
+                    //Add a Dummy Feat to prevent the feats menu from crashing
+                    (g.Top_Level.Fields.Where(x => x.Label == "FeatList").FirstOrDefault() as GFF.LIST).Structs.Add(new GFF.STRUCT("", 1, new List<GFF.FIELD>() {new GFF.WORD("Feat", 27) }));
+
+                    g.WriteToFile(paths.Override + ID.Item2 + ".utc");
+
+                }
+
             }
         }
     }


### PR DESCRIPTION
This option, found in OtherRando, will replace the party member templates with a random other creature template. This not only changes their appearance, but their class, stats, skills, and feats as well.  

Note: there are still some rare stability issues, like game crashes when Darth Bandon equips a torso item (I haven't observed this with any other creature as of yet)