### PR TITLE
Generate spoiler logs for Items, Models, and Modules.

### DIFF
--- a/kotor Randomizer 2/Forms/ItemForm.cs
+++ b/kotor Randomizer 2/Forms/ItemForm.cs
@@ -14,24 +14,24 @@ namespace kotor_Randomizer_2
             lbOmitItems.DataSource = Globals.OmitItems;
 
             //Set Intiial Values
-            RandomizeArmor = (RandomizationLevel)Properties.Settings.Default.RandomizeArmor;
-            RandomizeStims = (RandomizationLevel)Properties.Settings.Default.RandomizeStims;
-            RandomizeBelts = (RandomizationLevel)Properties.Settings.Default.RandomizeBelts;
-            RandomizeVarious = (RandomizationLevel)Properties.Settings.Default.RandomizeVarious;
-            RandomizeHides = (RandomizationLevel)Properties.Settings.Default.RandomizeHides;
             RandomizeArmbands = (RandomizationLevel)Properties.Settings.Default.RandomizeArmbands;
+            RandomizeArmor = (RandomizationLevel)Properties.Settings.Default.RandomizeArmor;
+            RandomizeBelts = (RandomizationLevel)Properties.Settings.Default.RandomizeBelts;
+            RandomizeBlasters = (RandomizationLevel)Properties.Settings.Default.RandomizeBlasters;
+            RandomizeHides = (RandomizationLevel)Properties.Settings.Default.RandomizeHides;
+            RandomizeCreature = (RandomizationLevel)Properties.Settings.Default.RandomizeCreature;
             RandomizeDroid = (RandomizationLevel)Properties.Settings.Default.RandomizeDroid;
             RandomizeGloves = (RandomizationLevel)Properties.Settings.Default.RandomizeGloves;
-            RandomizeImplants = (RandomizationLevel)Properties.Settings.Default.RandomizeImplants;
-            RandomizeMask = (RandomizationLevel)Properties.Settings.Default.RandomizeMask;
-            RandomizePaz = (RandomizationLevel)Properties.Settings.Default.RandomizePaz;
-            RandomizeMines = (RandomizationLevel)Properties.Settings.Default.RandomizeMines;
-            RandomizeUpgrade = (RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade;
-            RandomizeBlasters = (RandomizationLevel)Properties.Settings.Default.RandomizeBlasters;
-            RandomizeCreature = (RandomizationLevel)Properties.Settings.Default.RandomizeCreature;
-            RandomizeLightsabers = (RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers;
             RandomizeGrenades = (RandomizationLevel)Properties.Settings.Default.RandomizeGrenades;
+            RandomizeImplants = (RandomizationLevel)Properties.Settings.Default.RandomizeImplants;
+            RandomizeLightsabers = (RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers;
+            RandomizeMask = (RandomizationLevel)Properties.Settings.Default.RandomizeMask;
             RandomizeMelee = (RandomizationLevel)Properties.Settings.Default.RandomizeMelee;
+            RandomizeMines = (RandomizationLevel)Properties.Settings.Default.RandomizeMines;
+            RandomizePaz = (RandomizationLevel)Properties.Settings.Default.RandomizePaz;
+            RandomizeStims = (RandomizationLevel)Properties.Settings.Default.RandomizeStims;
+            RandomizeUpgrade = (RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade;
+            RandomizeVarious = (RandomizationLevel)Properties.Settings.Default.RandomizeVarious;
 
             // Create easy access lists.
             CheckBoxes.AddRange(new List<CheckBox>()

--- a/kotor Randomizer 2/Forms/StartForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/StartForm.Designer.cs
@@ -53,6 +53,8 @@
             this.bPresets = new System.Windows.Forms.Button();
             this.cms1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.generateSpoilersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openSpoilersFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.module_radio)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.item_radio)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sound_radio)).BeginInit();
@@ -67,11 +69,11 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Unispace", 11.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.label1.Location = new System.Drawing.Point(89, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(152, 18);
+            this.label1.Size = new System.Drawing.Size(146, 18);
             this.label1.TabIndex = 0;
             this.label1.Text = "Kotor Randomizer";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -83,7 +85,7 @@
             this.module_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.module_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.module_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.module_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.module_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.module_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.module_button.Location = new System.Drawing.Point(60, 50);
             this.module_button.Name = "module_button";
@@ -102,7 +104,7 @@
             this.item_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.item_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.item_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.item_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.item_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.item_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.item_button.Location = new System.Drawing.Point(60, 90);
             this.item_button.Name = "item_button";
@@ -121,7 +123,7 @@
             this.sound_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.sound_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.sound_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.sound_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.sound_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.sound_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.sound_button.Location = new System.Drawing.Point(60, 130);
             this.sound_button.Name = "sound_button";
@@ -140,7 +142,7 @@
             this.model_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.model_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.model_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.model_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.model_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.model_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.model_button.Location = new System.Drawing.Point(60, 170);
             this.model_button.Name = "model_button";
@@ -159,7 +161,7 @@
             this.texture_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.texture_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.texture_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.texture_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.texture_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.texture_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.texture_button.Location = new System.Drawing.Point(60, 210);
             this.texture_button.Name = "texture_button";
@@ -178,7 +180,7 @@
             this.twoda_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.twoda_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.twoda_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.twoda_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.twoda_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.twoda_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.twoda_button.Location = new System.Drawing.Point(60, 250);
             this.twoda_button.Name = "twoda_button";
@@ -197,7 +199,7 @@
             this.text_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.text_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.text_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.text_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.text_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.text_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.text_button.Location = new System.Drawing.Point(60, 290);
             this.text_button.Name = "text_button";
@@ -216,7 +218,7 @@
             this.other_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.other_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.other_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.other_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.other_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.other_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.other_button.Location = new System.Drawing.Point(60, 330);
             this.other_button.Name = "other_button";
@@ -235,7 +237,7 @@
             this.path_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.path_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.path_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.path_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.path_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.path_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.path_button.Location = new System.Drawing.Point(20, 370);
             this.path_button.Name = "path_button";
@@ -254,7 +256,7 @@
             this.randomize_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.randomize_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.randomize_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.randomize_button.Font = new System.Drawing.Font("Unispace", 14.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.randomize_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.randomize_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.randomize_button.Location = new System.Drawing.Point(20, 410);
             this.randomize_button.Name = "randomize_button";
@@ -385,7 +387,7 @@
             this.seed_button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.seed_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.seed_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.seed_button.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.seed_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.seed_button.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.seed_button.Location = new System.Drawing.Point(170, 370);
             this.seed_button.Name = "seed_button";
@@ -404,7 +406,7 @@
             this.bPresets.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.bPresets.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.bPresets.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.bPresets.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.bPresets.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.bPresets.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.bPresets.Location = new System.Drawing.Point(20, 470);
             this.bPresets.Name = "bPresets";
@@ -419,23 +421,40 @@
             // cms1
             // 
             this.cms1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.helpToolStripMenuItem});
+            this.helpToolStripMenuItem,
+            this.generateSpoilersToolStripMenuItem,
+            this.openSpoilersFolderToolStripMenuItem});
             this.cms1.Name = "contextMenuStrip1";
-            this.cms1.Size = new System.Drawing.Size(100, 26);
+            this.cms1.Size = new System.Drawing.Size(181, 92);
             // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(99, 22);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.helpToolStripMenuItem.Text = "Help";
             this.helpToolStripMenuItem.Click += new System.EventHandler(this.helpToolStripMenuItem_Click);
+            // 
+            // generateSpoilersToolStripMenuItem
+            // 
+            this.generateSpoilersToolStripMenuItem.Enabled = false;
+            this.generateSpoilersToolStripMenuItem.Name = "generateSpoilersToolStripMenuItem";
+            this.generateSpoilersToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.generateSpoilersToolStripMenuItem.Text = "Generate Spoilers";
+            this.generateSpoilersToolStripMenuItem.Click += new System.EventHandler(this.generateSpoilersToolStripMenuItem_Click);
+            // 
+            // openSpoilersFolderToolStripMenuItem
+            // 
+            this.openSpoilersFolderToolStripMenuItem.Name = "openSpoilersFolderToolStripMenuItem";
+            this.openSpoilersFolderToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.openSpoilersFolderToolStripMenuItem.Text = "Open Spoilers Folder";
+            this.openSpoilersFolderToolStripMenuItem.Click += new System.EventHandler(this.openSpoilersFolderToolStripMenuItem_Click);
             // 
             // StartForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(332, 521);
+            this.ClientSize = new System.Drawing.Size(332, 517);
             this.ContextMenuStrip = this.cms1;
             this.Controls.Add(this.bPresets);
             this.Controls.Add(this.seed_button);
@@ -506,6 +525,8 @@
         private System.Windows.Forms.Button bPresets;
         private System.Windows.Forms.ContextMenuStrip cms1;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem generateSpoilersToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openSpoilersFolderToolStripMenuItem;
     }
 }
 

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -45,6 +45,27 @@ namespace kotor_Randomizer_2
             }
         }
 
+        private void LogCurrentSettings()
+        {
+            string path = Path.Combine(Environment.CurrentDirectory, "current.krp");
+            if (File.Exists(path)) { File.Delete(path); }
+            KRP.WriteKRP(File.OpenWrite(path));
+        }
+
+        private void CreateSpoilerLogs()
+        {
+            string spoilersPath = Path.Combine(Environment.CurrentDirectory, "Spoilers");
+            //if (Directory.Exists(spoilersPath)) { Directory.Delete(spoilersPath, true); }
+            Directory.CreateDirectory(spoilersPath);
+
+            var timestamp = DateTime.Now.ToString("yy-MM-dd_HH-mm-ss");
+            ItemRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_items.csv"));
+            ModelRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_models.csv"));
+            ModuleRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_modules.csv"));
+
+            MessageBox.Show("Spoiler logs created.");
+        }
+
         #region  Events
 
         /// <summary>
@@ -225,6 +246,8 @@ namespace kotor_Randomizer_2
                 else
                 {
                     randomize_button.Text = "Unrandomize!";
+                    LogCurrentSettings();
+                    generateSpoilersToolStripMenuItem.Enabled = true;
                 }
 
                 new RandoForm().Show();
@@ -245,6 +268,16 @@ namespace kotor_Randomizer_2
             {
                 new HelpForm().Show();
             }
+        }
+
+        private void generateSpoilersToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CreateSpoilerLogs();
+        }
+
+        private void openSpoilersFolderToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            System.Diagnostics.Process.Start(Path.Combine(Environment.CurrentDirectory, "Spoilers"));
         }
         #endregion
     }

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -68,7 +68,7 @@ namespace kotor_Randomizer_2
         /// <summary> Allows Leviathan elevators to go to any of the other decks without prerequisites </summary>
         FixLevElevators = 0x100, // 0b01 00000000
         /// <summary> Adds a Load Zone leading the the Vulkar Spice in the rear of the Vulkar base main floor, next to the pool </summary>
-        VulkarSpiceLZ = 0x200, // 0b1000000000
+        VulkarSpiceLZ   = 0x200, // 0b10 00000000
     }
 
     [Flags]

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -88,6 +88,7 @@ namespace kotor_Randomizer_2
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixMindPrison; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.UnlockVarDoors; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixLevElevators; }
+                        if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.VulkarSpiceLZ; }
 
                         Properties.Settings.Default.LastPresetComboIndex = -2;
                         Properties.Settings.Default.ModulePresetSelected = false;
@@ -336,7 +337,7 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison));    // Fixed Rakatan Riddles
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors));   // Unlock Problem Doors
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators));  // Fixed Leviathan Elevators
-
+                    bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ));    // Add Vulkar Spice Loading Zone
                 }
                 // Items
                 if (Properties.Settings.Default.DoRandomization_Item)

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -11,33 +11,39 @@ namespace kotor_Randomizer_2
 {
     public static class ItemRando
     {
+        /// <summary>
+        /// A lookup table used to know how the items are randomized.
+        /// </summary>
+        private static Dictionary<string, string> LookupTable { get; set; } = new Dictionary<string, string>();
+
         public static void item_rando(KPaths paths)
         {
             // Prepare lists for new randomization.
             Max_Rando.Clear();
             Type_Lists.Clear();
+            LookupTable.Clear();
 
             // Load KEY file.
             KEY k = new KEY(paths.chitin);
 
             // Handle categories
-            HandleCategory(k, ArmorRegs, Properties.Settings.Default.RandomizeArmor);
-            HandleCategory(k, StimsRegs, Properties.Settings.Default.RandomizeStims);
-            HandleCategory(k, BeltsRegs, Properties.Settings.Default.RandomizeBelts);
-            HandleCategory(k, HidesRegs, Properties.Settings.Default.RandomizeHides);
-            HandleCategory(k, DroidRegs, Properties.Settings.Default.RandomizeDroid);
             HandleCategory(k, ArmbandsRegs, Properties.Settings.Default.RandomizeArmbands);
-            HandleCategory(k, GlovesRegs, Properties.Settings.Default.RandomizeGloves);
-            HandleCategory(k, ImplantsRegs, Properties.Settings.Default.RandomizeImplants);
-            HandleCategory(k, MaskRegs, Properties.Settings.Default.RandomizeMask);
-            HandleCategory(k, PazRegs, Properties.Settings.Default.RandomizePaz);
-            HandleCategory(k, MinesRegs, Properties.Settings.Default.RandomizeMines);
-            HandleCategory(k, UpgradeRegs, Properties.Settings.Default.RandomizeUpgrade);
+            HandleCategory(k, ArmorRegs, Properties.Settings.Default.RandomizeArmor);
+            HandleCategory(k, BeltsRegs, Properties.Settings.Default.RandomizeBelts);
             HandleCategory(k, BlastersRegs, Properties.Settings.Default.RandomizeBlasters);
+            HandleCategory(k, HidesRegs, Properties.Settings.Default.RandomizeHides);
             HandleCategory(k, CreatureRegs, Properties.Settings.Default.RandomizeCreature);
-            HandleCategory(k, LightsabersRegs, Properties.Settings.Default.RandomizeLightsabers);
+            HandleCategory(k, DroidRegs, Properties.Settings.Default.RandomizeDroid);
+            HandleCategory(k, GlovesRegs, Properties.Settings.Default.RandomizeGloves);
             HandleCategory(k, GrenadesRegs, Properties.Settings.Default.RandomizeGrenades);
+            HandleCategory(k, ImplantsRegs, Properties.Settings.Default.RandomizeImplants);
+            HandleCategory(k, LightsabersRegs, Properties.Settings.Default.RandomizeLightsabers);
+            HandleCategory(k, MaskRegs, Properties.Settings.Default.RandomizeMask);
             HandleCategory(k, MeleeRegs, Properties.Settings.Default.RandomizeMelee);
+            HandleCategory(k, MinesRegs, Properties.Settings.Default.RandomizeMines);
+            HandleCategory(k, PazRegs, Properties.Settings.Default.RandomizePaz);
+            HandleCategory(k, StimsRegs, Properties.Settings.Default.RandomizeStims);
+            HandleCategory(k, UpgradeRegs, Properties.Settings.Default.RandomizeUpgrade);
 
             //handle Various
             switch ((RandomizationLevel)Properties.Settings.Default.RandomizeVarious)
@@ -60,6 +66,7 @@ namespace kotor_Randomizer_2
             int j = 0;
             foreach (KEY.KeyEntry ke in k.KeyTable.Where(x => Max_Rando_Iterator.Contains(x.ResRef)))
             {
+                LookupTable.Add(ke.ResRef, Max_Rando[j]);
                 ke.ResRef = Max_Rando[j];
                 j++;
             }
@@ -72,6 +79,7 @@ namespace kotor_Randomizer_2
                 j = 0;
                 foreach (KEY.KeyEntry ke in k.KeyTable.Where(x => li.Contains(x.ResRef)))
                 {
+                    LookupTable.Add(ke.ResRef, type_copy[j]);
                     ke.ResRef = type_copy[j];
                     j++;
                 }
@@ -136,6 +144,60 @@ namespace kotor_Randomizer_2
         private static List<string> Max_Rando = new List<string>();
 
         private static List<List<string>> Type_Lists = new List<List<string>>();
+
+        /// <summary>
+        /// Creates a CSV file containing a list of the changes made during randomization.
+        /// If the file already exists, this method will append the data.
+        /// If no randomization has been performed, no file will be created.
+        /// </summary>
+        /// <param name="path">Path to desired output file.</param>
+        public static void GenerateSpoilerLog(string path)
+        {
+            if (LookupTable.Count == 0) { return; }
+            var sortedLookup = LookupTable.OrderBy(kvp => kvp.Key);
+
+            using (StreamWriter sw = new StreamWriter(path))
+            {
+                //sw.WriteLine("Items,");
+                sw.WriteLine($"Seed,{Properties.Settings.Default.Seed}");
+                sw.WriteLine();
+
+                sw.WriteLine("Item Type,Rando Level");
+                sw.WriteLine($"Armbands,{(RandomizationLevel)Properties.Settings.Default.RandomizeArmbands}");
+                sw.WriteLine($"Armor,{(RandomizationLevel)Properties.Settings.Default.RandomizeArmor}");
+                sw.WriteLine($"Belts,{(RandomizationLevel)Properties.Settings.Default.RandomizeBelts}");
+                sw.WriteLine($"Blasters,{(RandomizationLevel)Properties.Settings.Default.RandomizeBlasters}");
+                sw.WriteLine($"Creature Hides,{(RandomizationLevel)Properties.Settings.Default.RandomizeHides}");
+                sw.WriteLine($"Creature Weapons,{(RandomizationLevel)Properties.Settings.Default.RandomizeCreature}");
+                sw.WriteLine($"Droid Equipment,{(RandomizationLevel)Properties.Settings.Default.RandomizeDroid}");
+                sw.WriteLine($"Gauntlets,{(RandomizationLevel)Properties.Settings.Default.RandomizeGloves}");
+                sw.WriteLine($"Grenades,{(RandomizationLevel)Properties.Settings.Default.RandomizeGrenades}");
+                sw.WriteLine($"Implants,{(RandomizationLevel)Properties.Settings.Default.RandomizeImplants}");
+                sw.WriteLine($"Lightsabers,{(RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers}");
+                sw.WriteLine($"Masks,{(RandomizationLevel)Properties.Settings.Default.RandomizeMask}");
+                sw.WriteLine($"Melee Weapons,{(RandomizationLevel)Properties.Settings.Default.RandomizeMelee}");
+                sw.WriteLine($"Mines,{(RandomizationLevel)Properties.Settings.Default.RandomizeMines}");
+                sw.WriteLine($"Pazaak Cards,{(RandomizationLevel)Properties.Settings.Default.RandomizePaz}");
+                sw.WriteLine($"Stims/Medpacs,{(RandomizationLevel)Properties.Settings.Default.RandomizeStims}");
+                sw.WriteLine($"Upgrades/Crystals,{(RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade}");
+                sw.WriteLine($"Various,{(RandomizationLevel)Properties.Settings.Default.RandomizeVarious}");
+                sw.WriteLine();
+
+                sw.WriteLine("Omitted Items");
+                foreach (var item in Globals.OmitItems)
+                {
+                    sw.WriteLine(item);
+                }
+                sw.WriteLine();
+
+                sw.WriteLine("Has Changed,Original,Randomized");
+                foreach (var kvp in sortedLookup)
+                {
+                    sw.WriteLine($"{(kvp.Key != kvp.Value).ToString()},{kvp.Key},{kvp.Value}");
+                }
+                sw.WriteLine();
+            }
+        }
 
         #region Regexes
         //Armor Regexes

--- a/kotor Randomizer 2/Randomization/ModelRando.cs
+++ b/kotor Randomizer 2/Randomization/ModelRando.cs
@@ -1,20 +1,36 @@
 ﻿using System.Linq;
 using System.IO;
 using KotOR_IO;
+using System.Collections.Generic;
+using System;
 
 namespace kotor_Randomizer_2
 {
     public static class ModelRando
     {
+        /// <summary>
+        /// Lookup table for how models are randomized.
+        /// Usage: LookupTable[MapName][ModelType][Label] = (OriginalID, RandomizedID);
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, Dictionary<string, Tuple<int, int>>>> LookupTable { get; set; } = new Dictionary<string, Dictionary<string, Dictionary<string, Tuple<int, int>>>>();
+
         public static void model_rando(KPaths paths)
         {
+            const string CHARACTER = "Character";
+            const string DOOR = "Door";
+            const string PLACEABLE = "Placeable";
+            LookupTable.Clear();
+
             foreach (FileInfo fi in paths.FilesInModules)
             {
                 RIM r = new RIM(fi.FullName);
-                
+                LookupTable.Add(fi.Name, new Dictionary<string, Dictionary<string, Tuple<int, int>>>());
+
                 // Doors
                 if ((Properties.Settings.Default.RandomizeDoorModels & 1) > 0)
                 {
+                    LookupTable[fi.Name].Add(DOOR, new Dictionary<string, Tuple<int, int>>());
+
                     foreach (RIM.rFile rf in r.File_Table.Where(x => x.TypeID == (int)ResourceType.UTD))
                     {
                         GFF_old g = new GFF_old(rf.File_Data);
@@ -31,20 +47,28 @@ namespace kotor_Randomizer_2
                         }
 
                         // Airlock
-                        if ((Properties.Settings.Default.RandomizeDoorModels & 2) > 0 && (g.Field_Array.Where(x => x.Label == "LocName").FirstOrDefault().Field_Data as GFF_old.CExoLocString).StringRef == 21080) { continue; }
+                        if ((Properties.Settings.Default.RandomizeDoorModels & 2) > 0 &&
+                            (g.Field_Array.Where(x => x.Label == "LocName").FirstOrDefault().Field_Data as GFF_old.CExoLocString).StringRef == 21080)
+                        {
+                            continue;
+                        }
+
+                        var id = BitConverter.ToInt32((byte[])g.Field_Array.Where(k => k.Label == "GenericType").FirstOrDefault().Field_Data, 0);
+                        LookupTable[fi.Name][DOOR].Add(rf.Label, new Tuple<int, int>(id, temp));
+
                         g.Field_Array.Where(k => k.Label == "GenericType").FirstOrDefault().Field_Data = temp;
                         g.Field_Array.Where(k => k.Label == "GenericType").FirstOrDefault().DataOrDataOffset = temp;
-
-                        MemoryStream ms = new MemoryStream();
 
                         rf.File_Data = g.ToRawData();
                     }
                 }
 
-                //Placeables
+                // Placeables
                 if ((Properties.Settings.Default.RandomizePlaceModels & 1) > 0)
                 {
-                    foreach (RIM.rFile rf in r.File_Table.Where(k => k.TypeID == 2044))
+                    LookupTable[fi.Name].Add(PLACEABLE, new Dictionary<string, Tuple<int, int>>());
+
+                    foreach (RIM.rFile rf in r.File_Table.Where(k => k.TypeID == (int)ResourceType.UTP))
                     {
                         GFF_old g = new GFF_old(rf.File_Data);
 
@@ -63,19 +87,22 @@ namespace kotor_Randomizer_2
 
                         }
 
+                        var id = Convert.ToInt32(g.Field_Array.Where(k => k.Label == "Appearance").FirstOrDefault().Field_Data);
+                        LookupTable[fi.Name][PLACEABLE].Add(rf.Label, new Tuple<int, int>(id, temp));
+
                         g.Field_Array.Where(k => k.Label == "Appearance").FirstOrDefault().Field_Data = temp;
                         g.Field_Array.Where(k => k.Label == "Appearance").FirstOrDefault().DataOrDataOffset = temp;
-
-                        MemoryStream ms = new MemoryStream();
 
                         rf.File_Data = g.ToRawData();
                     }
                 }
 
-                //Characters
+                // Characters
                 if ((Properties.Settings.Default.RandomizeCharModels & 1) > 0)
                 {
-                    foreach (RIM.rFile rf in r.File_Table.Where(k => k.TypeID == 2027))
+                    LookupTable[fi.Name].Add(CHARACTER, new Dictionary<string, Tuple<int, int>>());
+
+                    foreach (RIM.rFile rf in r.File_Table.Where(k => k.TypeID == (int)ResourceType.UTC))
                     {
                         GFF_old g = new GFF_old(rf.File_Data);
 
@@ -91,16 +118,70 @@ namespace kotor_Randomizer_2
                             large_satisfied = !((Properties.Settings.Default.RandomizeCharModels & 2) > 0) || !Globals.LARGE_CHARS.Contains(temp);//Always satisifed if Large omission disabled
                         }
 
+                        var id = Convert.ToInt32(g.Field_Array.Where(k => k.Label == "Appearance_Type").FirstOrDefault().Field_Data);
+                        LookupTable[fi.Name][CHARACTER].Add(rf.Label, new Tuple<int, int>(id, temp));
+
                         g.Field_Array.Where(k => k.Label == "Appearance_Type").FirstOrDefault().Field_Data = temp;
                         g.Field_Array.Where(k => k.Label == "Appearance_Type").FirstOrDefault().DataOrDataOffset = temp;
-
-                        MemoryStream ms = new MemoryStream();
 
                         rf.File_Data = g.ToRawData();
                     }
                 }
 
                 r.WriteToFile(fi.FullName);
+            }
+        }
+
+        /// <summary>
+        /// Creates a CSV file containing a list of the changes made during randomization.
+        /// If the file already exists, this method will append the data.
+        /// If no randomization has been performed, no file will be created.
+        /// </summary>
+        /// <param name="path">Path to desired output file.</param>
+        public static void GenerateSpoilerLog(string path)
+        {
+            if (LookupTable.Count == 0)
+            {
+                return;
+            }
+
+            using (StreamWriter sw = new StreamWriter(path))
+            {
+                //sw.WriteLine("Model,");
+                sw.WriteLine($"Seed,{Properties.Settings.Default.Seed}");
+                sw.WriteLine();
+
+                bool IsActive = (Properties.Settings.Default.RandomizeCharModels & 1) > 0;
+                bool OmitFirst = (Properties.Settings.Default.RandomizeCharModels & 2) > 0;
+                bool OmitSecond = (Properties.Settings.Default.RandomizeCharModels & 4) > 0;
+                sw.WriteLine("Model Type,Is Active,Omit Large Models,Omit Broken Models");
+                sw.WriteLine($"Character Models,{IsActive},{OmitFirst},{OmitSecond}");
+
+                IsActive = (Properties.Settings.Default.RandomizePlaceModels & 1) > 0;
+                OmitFirst = (Properties.Settings.Default.RandomizePlaceModels & 2) > 0;
+                OmitSecond = (Properties.Settings.Default.RandomizePlaceModels & 4) > 0;
+                sw.WriteLine("Model Type,Is Active,Omit Large Models,Omit Broken Models");
+                sw.WriteLine($"Placeable Models,{IsActive},{OmitFirst},{OmitSecond}");
+
+                IsActive = (Properties.Settings.Default.RandomizeDoorModels & 1) > 0;
+                OmitFirst = (Properties.Settings.Default.RandomizeDoorModels & 2) > 0;
+                OmitSecond = (Properties.Settings.Default.RandomizeDoorModels & 4) > 0;
+                sw.WriteLine("Model Type,Is Active,Omit Airlocks,Omit Broken Models");
+                sw.WriteLine($"Door Models,{IsActive},{OmitFirst},{OmitSecond}");
+                sw.WriteLine();
+
+                sw.WriteLine("Map Filename,Model Type,Model Label,Original ID,Randomized ID");
+                foreach (var map in LookupTable)
+                {
+                    foreach (var type in map.Value)
+                    {
+                        foreach (var kvp in type.Value)
+                        {
+                            sw.WriteLine($"{map.Key},{type.Key},{kvp.Key},{kvp.Value.Item1},{kvp.Value.Item2}");
+                        }
+                    }
+                }
+                sw.WriteLine();
             }
         }
     }


### PR DESCRIPTION
Fix for Issue #7.

Users now have the option in the contextual menu to create a spoiler log for Items, Models, and Modules in CSV format after randomization. A link to the spoilers folder is also available in the same menu.

Upon randomization, the current settings are saved in a KRP file named "current.krp" within the app startup directory. This can help with troubleshooting without using up much storage space.