### PR TITLE
Module goal-based reachability

### DIFF
--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -223,6 +223,30 @@
             <setting name="RandomizePartyMembers" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="VerifyReachability" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GoalIsMalak" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GoalIsPazaak" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GoalIsStarMaps" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AllowGlitchClip" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AllowGlitchDlz" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AllowGlitchFlu" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AllowGlitchGpw" serializeAs="String">
+                <value>False</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -247,6 +247,9 @@
             <setting name="AllowGlitchGpw" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="IgnoreOnceEdges" serializeAs="String">
+                <value>True</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/Digraph.cs
+++ b/kotor Randomizer 2/Digraph.cs
@@ -1,0 +1,730 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace kotor_Randomizer_2
+{
+    /// <summary>
+    /// Collection of constants used for parsing modules and edges from an XML file.
+    /// </summary>
+    public struct XmlConsts
+    {
+        // Games
+        public const string GAME_KOTOR_1 = "Kotor1"; // Modules
+        public const string GAME_KOTOR_2 = "Kotor2"; // Modules
+
+        // Elements
+        public const string ELEM_MODULES  = "Modules"; // Modules
+        public const string ELEM_MODULE   = "Module";  // Vertex
+        public const string ELEM_LEADS_TO = "LeadsTo"; // Edge
+
+        // Attributes
+        public const string ATTR_GAME       = "Game";       // Modules
+        public const string ATTR_CODE       = "WarpCode";   // Vertex, Edge
+        public const string ATTR_NAME       = "CommonName"; // Vertex, Edge
+        public const string ATTR_TAGS       = "Tags";       // Vertex, Edge
+        public const string ATTR_LOCKED_TAG = "LockedTag";  // Vertex
+        public const string ATTR_UNLOCK     = "Unlock";     // Vertex, Edge
+
+        // General
+        public const char   TAG_SEPARATOR = ',';
+
+        // Blocking Tags ... Edge (Tags)
+        public const string TAG_FAKE      = "Fake";
+        public const string TAG_LOCKED    = "Locked";
+        public const string TAG_ONCE      = "Once";
+
+        // Goal Tags ... Vertex (Tags)
+        public const string TAG_MALAK    = "Malak";
+        public const string TAG_PAZAAK   = "Pazaak";
+        public const string TAG_START    = "Start";
+        public const string TAG_STAR_MAP = "StarMap";
+
+        // Party Tags ... Vertex (Tags, LockedTag), Edge (Unlock)
+        public const string TAG_BASTILA   = "Bastila";
+        public const string TAG_CANDEROUS = "Canderous";
+        public const string TAG_CARTH     = "Carth";
+        public const string TAG_HK47      = "HK47";
+        public const string TAG_JOLEE     = "Jolee";
+        public const string TAG_JUHANI    = "Juhani";
+        public const string TAG_MISSION   = "Mission";
+        public const string TAG_T3M4      = "T3M4";
+        public const string TAG_ZAALBAR   = "Zaalbar";
+
+        // Glitch Tags ... Edge (Tags)
+        public const string TAG_CLIP = "Clip";
+        public const string TAG_DLZ = "DLZ";
+        public const string TAG_FLU = "FLU";
+        public const string TAG_GPW = "GPW";
+
+        // Fix Tags ... Edge (Tags)
+        public const string TAG_FIX_BOX   = "FixBox";
+        public const string TAG_FIX_DOORS = "FixDoors";
+        public const string TAG_FIX_ELEV  = "FixElev";
+        public const string TAG_FIX_MAP   = "FixMap";
+        public const string TAG_FIX_SPICE = "FixSpice";
+    }
+
+    /// <summary>
+    /// Directional graph of the layout of game modules. Implements reachability testing for module randomization.
+    /// </summary>
+    public class ModuleDigraph
+    {
+        #region Properties
+        /// <summary> Collection of parsed modules that are the vertices of the digraph. </summary>
+        public List<ModuleVertex> Modules { get; }
+        /// <summary> Lookup that indicates which modules are reachable. Reachable[WarpCode] = isReachable; </summary>
+        public Dictionary<string, bool> Reachable { get; private set; }
+        /// <summary> Flag indicating that the Reachable lookup table has been updated in the latest cycle of DFS. </summary>
+        private bool ReachableUpdated { get; set; } = false;
+        /// <summary> Queue containing edges labeled with the Once tag. These will be checked after every other option has been taken during a cycle. </summary>
+        public Queue<ModuleEdge> OnceQueue { get; } = new Queue<ModuleEdge>();
+        /// <summary> Lookup table for the randomization. RandomLookup[Original.WarpCode] = Randomized.WarpCode; </summary>
+        public Dictionary<string, string> RandomLookup  { get; set; }
+
+        /// <summary> Reaching the tag(s) Malak is a goal for this randomization. </summary>
+        public bool GoalIsMalak   { get; set; } = true;
+        /// <summary> Reaching the tag(s) Pazaak is a goal for this randomization. </summary>
+        public bool GoalIsPazaak  { get; set; } = false;
+        /// <summary> Reaching the tag(s) StarMap is a goal for this randomization. </summary>
+        public bool GoalIsStarMap { get; set; } = false;
+
+        /// <summary> Allow usage of the glitch Clipping to bypass locked edges. </summary>
+        public bool AllowGlitchClip { get; set; } = false;
+        /// <summary> Allow usage of the glitch DLZ to bypass locked edges. </summary>
+        public bool AllowGlitchDlz { get; set; } = false;
+        /// <summary> Allow usage of the glitch FLU to bypass locked edges. </summary>
+        public bool AllowGlitchFlu { get; set; } = false;
+        /// <summary> Allow usage of the glitch GPW to bypass locked edges. </summary>
+        public bool AllowGlitchGpw { get; set; } = false;
+
+        /// <summary> Locked edges will be ignored until they are unlocked. </summary>
+        public bool EnforceEdgeTagLocked { get; set; } = true;
+        /// <summary> Once edges will be ignored, as they are unreliable. </summary>
+        public bool EnforceEdgeTagOnce   { get; set; } = true;
+
+        /// <summary> FixBox is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledFixBox   { get; set; } = false;
+        /// <summary> FixDoors is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledFixDoors { get; set; } = false;
+        /// <summary> FixElev is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledFixElev  { get; set; } = false;
+        /// <summary> FixMap is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledFixMap   { get; set; } = false;
+        /// <summary> FixSpice is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledFixSpice { get; set; } = false;
+        #endregion
+
+        /// <summary>
+        /// Creates a digraph of the modules in the given XML file and checks reachability.
+        /// </summary>
+        /// <param name="path">Full path to the XML file to parse.</param>
+        /// <param name="lookup">Lookup dictionary from original code to a randomized code.</param>
+        public ModuleDigraph(string path)
+        {
+            // Parse XML document containing game modules.
+            XDocument doc = XDocument.Load(path);
+            var game = doc.Descendants(XmlConsts.ELEM_MODULES).FirstOrDefault(x => x.Attributes().Where(a => a.Name == XmlConsts.ATTR_GAME && a.Value == XmlConsts.GAME_KOTOR_1).Any());
+            Modules = game.Descendants(XmlConsts.ELEM_MODULE).Select(x => new ModuleVertex(x)).ToList();
+
+            // Create a fake lookup (original -> original).
+            RandomLookup = Modules.ToDictionary(m => m.WarpCode, m => m.WarpCode);
+
+            // Get currently enabled settings.
+            AllowGlitchClip = Properties.Settings.Default.AllowGlitchClip;
+            AllowGlitchDlz = Properties.Settings.Default.AllowGlitchDlz;
+            AllowGlitchFlu = Properties.Settings.Default.AllowGlitchFlu;
+            AllowGlitchGpw = Properties.Settings.Default.AllowGlitchGpw;
+            EnabledFixBox = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
+            EnabledFixDoors = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
+            EnabledFixElev = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
+            EnabledFixMap = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
+            EnabledFixSpice = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ);
+            EnforceEdgeTagLocked = true;
+            EnforceEdgeTagOnce = true;
+            GoalIsMalak = Properties.Settings.Default.GoalIsMalak;
+            GoalIsPazaak = Properties.Settings.Default.GoalIsPazaak;
+            GoalIsStarMap = Properties.Settings.Default.GoalIsStarMaps;
+        }
+
+        /// <summary>
+        /// Writes all reachable modules and their (randomized) edges to the console for debugging purposes.
+        /// </summary>
+        private void WriteReachableToConsole()
+        {
+            foreach (var vertex in Reachable.Where(kvp => kvp.Value == true))
+            {
+                if (!Modules.Any(v => v.WarpCode == vertex.Key)) continue;
+                var module = Modules.Find(v => v.WarpCode == vertex.Key);
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append($"{module.WarpCode}");
+
+                if (module.Tags.Count > 0)
+                    sb.Append($" [{module.Tags.Aggregate((i, j) => $"{i},{j}")}]");
+
+                if (!string.IsNullOrWhiteSpace(module.LockedTag))
+                    sb.Append($" -[{module.LockedTag}]-");
+
+                if (module.Unlock.Count > 0)
+                    sb.Append($" =[{module.Unlock.Aggregate((i, j) => $"{i},{j}")}]=");
+
+                sb.AppendLine();
+
+                foreach (var edge in module.LeadsTo)
+                {
+                    sb.Append($"-> {edge.WarpCode} ({RandomLookup[edge.WarpCode]})");
+
+                    if (edge.Tags.Count > 0)
+                        sb.Append($" [{edge.Tags.Aggregate((i, j) => $"{i},{j}")}]");
+
+                    if (edge.Unlock.Count > 0)
+                        sb.Append($" =[{edge.Unlock.Aggregate((i, j) => $"{i},{j}")}]=");
+
+                    sb.AppendLine();
+                }
+
+                Console.Write(sb.ToString());
+            }
+        }
+
+        #region Reachability
+        /// <summary>
+        /// Updates the randomization lookup table.
+        /// </summary>
+        /// <param name="lookup">New lookup table.</param>
+        public void SetRandomizationLookup(Dictionary<string, string> lookup)
+        {
+            if (lookup.Values.Distinct().Count() == lookup.Values.Count)
+                RandomLookup = lookup.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+            else
+                throw new ArgumentException("Lookup table does not have both a distinct set of keys and values.");
+        }
+
+        /// <summary>
+        /// Begin the reachability search.
+        /// </summary>
+        public void CheckReachability()
+        {
+            Console.WriteLine("Time used to create digraph and check reachability...");
+            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+            sw.Start();
+
+            // Reset objects needed for reachability testing.
+            Reachable = Modules.ToDictionary(m => m.WarpCode, b => false);
+            OnceQueue.Clear();
+
+            // Check reachability again to find unlocked edges.
+            CheckReachabilityDFS(Reachable);
+
+            // Continue to check to find newly unlocked edges, until none are unlocked.
+            do
+            {
+                ReachableUpdated = false;
+                var touched = Reachable.ToDictionary(kvp => kvp.Key, kvp => false);
+                CheckReachabilityDFS(touched);
+            } while (ReachableUpdated);
+
+            Console.WriteLine(sw.Elapsed.ToString());
+            Console.WriteLine();
+
+            WriteReachableToConsole();
+            Console.WriteLine();
+        }
+
+        /// <summary>
+        /// Begins the Depth-First Search reachability checking.
+        /// </summary>
+        /// <param name="touched">Dictionary indicating if each module has been checked during this cycle.</param>
+        /// <param name="origStart">Module where the depth-first search will begin. If null, the Start tag is used.</param>
+        private void CheckReachabilityDFS(Dictionary<string, bool> touched, ModuleVertex origStart = null)
+        {
+            if (origStart == null) origStart = Modules.Find(v => v.IsStart);
+            var randStart = Modules.Find(v => v.WarpCode == RandomLookup[origStart.WarpCode]);
+
+            // Search through all modules connected to the start. For now, treat start as not reachable
+            // since we may have no opportunity to return here.
+            foreach (var w in randStart.LeadsTo)
+            {
+                if (EnforceEdgeTagOnce && CanIgnoreOnceEdge(w))
+                {
+                    if (!Reachable[RandomLookup[w.WarpCode]] && !OnceQueue.Contains(w))
+                    {
+                        OnceQueue.Enqueue(w);
+                        ReachableUpdated = true;
+                    }
+                    continue;
+                }
+                if (EnforceEdgeTagLocked && CanIgnoreLockedEdge(w)) { continue; }
+                DepthFirstSearch(touched, Modules.Find(m => m.WarpCode == RandomLookup[w.WarpCode]));
+            }
+
+            // Check edges marked as Once for reachability.
+            for (int i = 0; i < OnceQueue.Count; i++)
+            {
+                var once = OnceQueue.Dequeue();
+                
+                // Remove if already reachable.
+                if (Reachable[RandomLookup[once.WarpCode]]) continue;
+
+                // Send to back if still locked.
+                if (EnforceEdgeTagLocked && CanIgnoreLockedEdge(once))
+                {
+                    OnceQueue.Enqueue(once);
+                    //ReachableUpdated = true;
+                    continue;
+                }
+
+                // Otherwise, visit.
+                DepthFirstSearch(touched, Modules.Find(m => m.WarpCode == RandomLookup[once.WarpCode]));
+            }
+        }
+
+        /// <summary>
+        /// Recursive method to perform Depth-First Search reachability checking.
+        /// </summary>
+        /// <param name="touched">Dictionary indicating if each module has been checked during this cycle.</param>
+        /// <param name="v">The current module to check.</param>
+        private void DepthFirstSearch(Dictionary<string, bool> touched, ModuleVertex v)
+        {
+            // This module has been reached, so assume reachable.
+            touched[v.WarpCode] = true;
+            if (touched[v.WarpCode] != Reachable[v.WarpCode])
+            {
+                ReachableUpdated = true;
+                Reachable[v.WarpCode] = true;
+            }
+
+            // Any tags associated with this vertex are also reachable.
+            foreach (var t in v.Tags)
+            {
+                if (!Reachable.ContainsKey(t)) Reachable.Add(t, true);
+                else Reachable[t] = true;
+            }
+
+            // Check to see if the locked tag is reachable too.
+            if (!string.IsNullOrWhiteSpace(v.LockedTag))
+            {
+                var isUnlocked = true;
+
+                // If ALL tags are reachable, this tag is also reachable.
+                foreach (var ul in v.Unlock)
+                {
+                    if (Reachable.ContainsKey(ul) && Reachable[ul]) isUnlocked = true;
+                    else
+                    {
+                        isUnlocked = false;
+                        break;
+                    }
+                }
+
+                if (!Reachable.ContainsKey(v.LockedTag)) Reachable.Add(v.LockedTag, isUnlocked);
+                else Reachable[v.LockedTag] = isUnlocked;
+            }
+
+            // Check each edge that hasn't been reached already.
+            foreach (var w in v.LeadsTo)
+            {
+                if (EnforceEdgeTagOnce && CanIgnoreOnceEdge(w))
+                {
+                    if (!Reachable[RandomLookup[w.WarpCode]] && !OnceQueue.Contains(w))
+                    {
+                        OnceQueue.Enqueue(w);
+                        ReachableUpdated = true;
+                    }
+                    continue;
+                }
+                if (EnforceEdgeTagLocked && CanIgnoreLockedEdge(w)) continue;
+                if (!touched[RandomLookup[w.WarpCode]]) DepthFirstSearch(touched, Modules.Find(m => m.WarpCode == RandomLookup[w.WarpCode]));
+            }
+        }
+
+        /// <summary>
+        /// If the edge contains the Once tag it should be skipped unless an enabled fix is also tagged.
+        /// </summary>
+        /// <param name="edge">Edge to check.</param>
+        /// <returns>True if the edge can be skipped.</returns>
+        private bool CanIgnoreOnceEdge(ModuleEdge edge)
+        {
+            bool isOnce = false;
+            if (edge.IsOnce)
+            {
+                if ((EnabledFixBox && edge.IsFixBox    ) ||
+                    (EnabledFixDoors && edge.IsFixDoors) ||
+                    (EnabledFixElev && edge.IsFixElev  ) ||
+                    (EnabledFixMap && edge.IsFixMap    ) ||
+                    (EnabledFixSpice && edge.IsFixSpice))
+                {
+                    isOnce = false;
+                }
+                else
+                {
+                    isOnce = true;
+                }
+            }
+            else
+            {
+                isOnce = false;
+            }
+            return isOnce;
+        }
+
+        /// <summary>
+        /// If the edge contains the Locked tag it should be skipped unless an enabled fix or glitch is also tagged or
+        /// if all of the edge's unlocks are reachable.
+        /// </summary>
+        /// <param name="edge">Edge to check.</param>
+        /// <returns>True if the edge can be skipped.</returns>
+        private bool CanIgnoreLockedEdge(ModuleEdge edge)
+        {
+            bool isLocked = false;
+            if (edge.IsLocked)
+            {
+                // Check to see if we can bypass this lock with an allowed glitch or enabled fix.
+                if ((AllowGlitchClip && edge.IsClip    ) ||
+                    (AllowGlitchDlz && edge.IsDlz      ) ||
+                    (AllowGlitchFlu && edge.IsFlu      ) || // How to handle FluReq? One FLU still requires Carth...
+                    (AllowGlitchGpw && edge.IsGpw      ) ||
+                    (EnabledFixBox && edge.IsFixBox    ) ||
+                    (EnabledFixDoors && edge.IsFixDoors) ||
+                    (EnabledFixElev && edge.IsFixElev  ) ||
+                    (EnabledFixMap && edge.IsFixMap    ) ||
+                    (EnabledFixSpice && edge.IsFixSpice))
+                {
+                    isLocked = false;
+                }
+                else
+                {
+                    // Check to see if the edge can be unlocked. ALL vertices need to be reachable.
+                    var unlocked = true;
+                    foreach (var target in edge.Unlock)
+                    {
+                        // If not in Reachable, then it's a new tag that we haven't seen.
+                        if (!Reachable.ContainsKey(target))
+                        {
+                            // Find the vertices that contain the tag, and see if we've reached ANY of them.
+                            // If not found, look for a LockedTag. Then check the Unlock for this tag.
+                            Reachable.Add(target, false);
+                            unlocked = false;
+                            break;
+                        }
+
+                        // If not Reachable, then the edge is still locked.
+                        if (!Reachable[target])
+                        {
+                            unlocked = false;
+                            break;
+                        }
+                    }
+
+                    if (unlocked)
+                    {
+                        isLocked = false;
+                    }
+                    else
+                    {
+                        isLocked = true;
+                    }
+                }
+            }
+            else
+            {
+                // Edge isn't locked.
+                isLocked = false;
+            }
+            return isLocked;
+        }
+        #endregion
+
+        #region IsReachable
+        /// <summary>
+        /// Returns true if all vertices in the given collection are reachable. Returns true if empty.
+        /// </summary>
+        /// <param name="ends">Vertices to check for reachability.</param>
+        private bool IsReachable(IEnumerable<ModuleVertex> ends)
+        {
+            bool goal = true;
+            foreach (var end in ends)
+            {
+                goal &= Reachable[RandomLookup.Where(kvp => kvp.Value == end.WarpCode).First().Key];
+            }
+            return goal;
+        }
+
+        /// <summary>
+        /// Returns true if all Malak modules are reachable.
+        /// </summary>
+        public bool IsMalakReachable()
+        {
+            return IsReachable(Modules.Where(v => v.IsMalak));
+        }
+
+        /// <summary>
+        /// Returns true if all Pazaak modules are reachable.
+        /// </summary>
+        public bool IsPazaakReachable()
+        {
+            return IsReachable(Modules.Where(v => v.IsPazaak));
+        }
+
+        /// <summary>
+        /// Returns true if all StarMap modules are reachable.
+        /// </summary>
+        public bool IsStarMapReachable()
+        {
+            return IsReachable(Modules.Where(v => v.IsStarMap));
+        }
+
+        /// <summary>
+        /// Returns true if all active goals are reachable. Returns true if no goals are active.
+        /// </summary>
+        public bool IsGoalReachable()
+        {
+            bool goal = true;
+            if (GoalIsMalak) goal &= IsMalakReachable();
+            if (GoalIsPazaak) goal &= IsPazaakReachable();
+            if (GoalIsStarMap) goal &= IsStarMapReachable();
+            return goal;
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Parsed module information for the ModuleDigraph.
+    /// </summary>
+    public class ModuleVertex
+    {
+        #region Properties
+        public string WarpCode          { get; }
+        public string CommonName        { get; }
+        public List<ModuleEdge> LeadsTo { get; } = new List<ModuleEdge>();
+
+        public bool IsMalak   { get; } = false;
+        public bool IsPazaak  { get; } = false;
+        public bool IsStart   { get; } = false;
+        public bool IsStarMap { get; } = false;
+
+        public bool IsBastila   { get; } = false;
+        public bool IsCanderous { get; } = false;
+        public bool IsCarth     { get; } = false;
+        public bool IsHK47      { get; } = false;
+        public bool IsJolee     { get; } = false;
+        public bool IsJuhani    { get; } = false;
+        public bool IsMission   { get; } = false;
+        public bool IsT3M4      { get; } = false;
+        public bool IsZaalbar   { get; } = false;
+
+        public List<string> Tags { get; } = new List<string>();
+        public string LockedTag { get; }
+        public List<string> Unlock { get; } = new List<string>();
+        #endregion
+
+        public ModuleVertex(XElement element)
+        {
+            // Check for null parameter.
+            if (element == null)
+                throw new ArgumentException("Parameter \'element\' can't be null.", "element");
+
+            // Get WarpCode
+            var code = element.Attribute(XmlConsts.ATTR_CODE);
+            if (code == null || string.IsNullOrEmpty(code.Value))
+                throw new ArgumentException("No \'WarpCode\' attribute found in the XML element.");
+            else
+                WarpCode = code.Value;
+
+            // Get CommonName
+            var name = element.Attribute(XmlConsts.ATTR_NAME);
+            if (name == null || string.IsNullOrEmpty(name.Value))
+                throw new ArgumentException("No \'CommonName\' attribute found in the XML element.");
+            else
+                CommonName = name.Value;
+
+            // Get list of Tags
+            var tags = element.Attribute(XmlConsts.ATTR_TAGS);
+            if (tags != null && !string.IsNullOrWhiteSpace(tags.Value))
+            {
+                foreach (var tag in tags.Value.Split(XmlConsts.TAG_SEPARATOR))
+                    Tags.Add(tag);
+            }
+
+            // Parse Tags
+            IsMalak   = Tags.Contains(XmlConsts.TAG_MALAK);
+            IsPazaak  = Tags.Contains(XmlConsts.TAG_PAZAAK);
+            IsStart   = Tags.Contains(XmlConsts.TAG_START);
+            IsStarMap = Tags.Contains(XmlConsts.TAG_STAR_MAP);
+
+            IsBastila   = Tags.Contains(XmlConsts.TAG_BASTILA);
+            IsCanderous = Tags.Contains(XmlConsts.TAG_CANDEROUS);
+            IsCarth     = Tags.Contains(XmlConsts.TAG_CARTH);
+            IsHK47      = Tags.Contains(XmlConsts.TAG_HK47);
+            IsJolee     = Tags.Contains(XmlConsts.TAG_JOLEE);
+            IsJuhani    = Tags.Contains(XmlConsts.TAG_JUHANI);
+            IsMission   = Tags.Contains(XmlConsts.TAG_MISSION);
+            IsT3M4      = Tags.Contains(XmlConsts.TAG_T3M4);
+            IsZaalbar   = Tags.Contains(XmlConsts.TAG_ZAALBAR);
+
+            // Get LockedTag
+            LockedTag = element.Attribute(XmlConsts.ATTR_LOCKED_TAG)?.Value; // Null if it doesn't exist.
+
+            // Get list of Unlocks
+            var unlocks = element.Attribute(XmlConsts.ATTR_UNLOCK);
+            if (unlocks != null && !string.IsNullOrWhiteSpace(unlocks.Value))
+            {
+                foreach (var unlock in unlocks.Value.Split(XmlConsts.TAG_SEPARATOR))
+                    Unlock.Add(unlock);
+            }
+
+            // Get adjacent vertices
+            var descendants = element.Descendants(XmlConsts.ELEM_LEADS_TO);
+            foreach (var desc in descendants)
+            {
+                LeadsTo.Add(new ModuleEdge(desc));
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append($"Code: {WarpCode}, Name: {CommonName}");
+            if (Tags.Count > 0)
+            {
+                sb.Append($", Tags: [{Tags.Aggregate((i, j) => $"{i},{j}")}]");
+            }
+            else
+            {
+                sb.Append(", Tags: []");
+            }
+
+            if (!string.IsNullOrWhiteSpace(LockedTag))
+            {
+                sb.Append($", LockedTag: {LockedTag}");
+            }
+
+            if (Unlock.Count > 0)
+            {
+                sb.Append($", Unlock: [{Unlock.Aggregate((i, j) => $"{i},{j}")}]");
+            }
+
+            if (LeadsTo.Count > 0)
+            {
+                sb.Append(" -> [");
+                sb.Append(LeadsTo[0].WarpCode);
+                for (int i = 1; i < LeadsTo.Count; i++)
+                {
+                    sb.Append(", ");
+                    sb.Append(LeadsTo[i].WarpCode);
+                }
+                sb.Append("]");
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Parsed information describing the transition from one module to another.
+    /// </summary>
+    public class ModuleEdge
+    {
+        #region Properties
+        public string WarpCode   { get; }
+        public string CommonName { get; }
+
+        public bool IsFake   { get; } = false;
+        public bool IsLocked { get; } = false;
+        public bool IsOnce   { get; } = false;
+
+        public bool IsClip { get; } = false;
+        public bool IsDlz { get; } = false;
+        public bool IsFlu { get; } = false;
+        public bool IsGpw { get; } = false;
+
+        public bool IsFixBox   { get; } = false;
+        public bool IsFixDoors { get; } = false;
+        public bool IsFixElev  { get; } = false;
+        public bool IsFixMap   { get; } = false;
+        public bool IsFixSpice { get; } = false;
+
+        public List<string> Tags { get; } = new List<string>();
+        //public bool HasTags() { return Tags.Count > 0; }
+        public List<string> Unlock { get; } = new List<string>();
+        #endregion
+
+        public ModuleEdge(XElement element)
+        {
+            // Check for null parameter.
+            if (element == null)
+                throw new ArgumentException("Parameter \'element\' can't be null.", "element");
+
+            // Get WarpCode
+            var code = element.Attribute(XmlConsts.ATTR_CODE);
+            if (code == null || string.IsNullOrEmpty(code.Value))
+                throw new ArgumentException("No \'WarpCode\' attribute found in the XML element.");
+            else
+                WarpCode = code.Value;
+
+            // Get CommonName
+            var name = element.Attribute(XmlConsts.ATTR_NAME);
+            if (name == null || string.IsNullOrEmpty(name.Value))
+                throw new ArgumentException("No \'CommonName\' attribute found in the XML element.");
+            else
+                CommonName = name.Value;
+
+            // Get list of Tags
+            var tags = element.Attribute(XmlConsts.ATTR_TAGS);
+            if (tags != null && !string.IsNullOrWhiteSpace(tags.Value))
+            {
+                foreach (var tag in tags.Value.Split(XmlConsts.TAG_SEPARATOR))
+                    Tags.Add(tag);
+            }
+
+            var unlocks = element.Attribute(XmlConsts.ATTR_UNLOCK);
+            if (unlocks != null && !string.IsNullOrWhiteSpace(unlocks.Value))
+            {
+                foreach (var unlock in unlocks.Value.Split(XmlConsts.TAG_SEPARATOR))
+                    Unlock.Add(unlock);
+            }
+
+            // Parse list of Tags
+            IsFake = Tags.Contains(XmlConsts.TAG_FAKE);
+            IsLocked = Tags.Contains(XmlConsts.TAG_LOCKED);
+            IsOnce   = Tags.Contains(XmlConsts.TAG_ONCE);
+
+            IsClip = Tags.Contains(XmlConsts.TAG_CLIP);
+            IsDlz = Tags.Contains(XmlConsts.TAG_DLZ);
+            IsFlu = Tags.Contains(XmlConsts.TAG_FLU);
+            IsGpw = Tags.Contains(XmlConsts.TAG_GPW);
+
+            IsFixBox   = Tags.Contains(XmlConsts.TAG_FIX_BOX);
+            IsFixDoors = Tags.Contains(XmlConsts.TAG_FIX_DOORS);
+            IsFixElev  = Tags.Contains(XmlConsts.TAG_FIX_ELEV);
+            IsFixMap   = Tags.Contains(XmlConsts.TAG_FIX_MAP);
+            IsFixSpice = Tags.Contains(XmlConsts.TAG_FIX_SPICE);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append($"Code: {WarpCode}, Name: {CommonName}");
+            if (Tags.Count > 0)
+            {
+                sb.Append($", Tags: [{Tags.Aggregate((i, j) => $"{i},{j}")}]");
+            }
+            else
+            {
+                sb.Append(", Tags: []");
+            }
+
+            if (Unlock.Count > 0)
+            {
+                sb.Append($", Unlock: [{Unlock.Aggregate((i, j) => $"{i},{j}")}]");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -58,6 +58,7 @@
             this.panel1 = new System.Windows.Forms.Panel();
             this.ModulesToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.cbGlitchClip = new System.Windows.Forms.CheckBox();
+            this.cbIgnoreOnceEdges = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // OmittedListBox
@@ -419,12 +420,28 @@
             this.cbGlitchClip.UseVisualStyleBackColor = true;
             this.cbGlitchClip.CheckedChanged += new System.EventHandler(this.cbGlitchClip_CheckedChanged);
             // 
+            // cbIgnoreOnceEdges
+            // 
+            this.cbIgnoreOnceEdges.AutoSize = true;
+            this.cbIgnoreOnceEdges.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbIgnoreOnceEdges.Location = new System.Drawing.Point(180, 588);
+            this.cbIgnoreOnceEdges.Name = "cbIgnoreOnceEdges";
+            this.cbIgnoreOnceEdges.Size = new System.Drawing.Size(164, 17);
+            this.cbIgnoreOnceEdges.TabIndex = 43;
+            this.cbIgnoreOnceEdges.Text = "Ignore Single-Use Transitions";
+            this.ModulesToolTip.SetToolTip(this.cbIgnoreOnceEdges, "The reachability algorithm will ignore one-time use loading\r\nzones or transitions" +
+        " to fulfill the reachability condition.\r\n*Enable this option for a more stable r" +
+        "andomization.*");
+            this.cbIgnoreOnceEdges.UseVisualStyleBackColor = true;
+            this.cbIgnoreOnceEdges.CheckedChanged += new System.EventHandler(this.cbAllowOnceEdges_CheckedChanged);
+            // 
             // ModuleForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.ClientSize = new System.Drawing.Size(541, 667);
+            this.Controls.Add(this.cbIgnoreOnceEdges);
             this.Controls.Add(this.cbGlitchClip);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.cbGlitchGpw);
@@ -494,5 +511,6 @@
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.ToolTip ModulesToolTip;
         private System.Windows.Forms.CheckBox cbGlitchClip;
+        private System.Windows.Forms.CheckBox cbIgnoreOnceEdges;
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ModuleForm));
             this.OmittedListBox = new System.Windows.Forms.ListBox();
             this.RandomizedListBox = new System.Windows.Forms.ListBox();
             this.PresetComboBox = new System.Windows.Forms.ComboBox();
@@ -44,6 +46,18 @@
             this.cbDoorFix = new System.Windows.Forms.CheckBox();
             this.cbFixLevElevators = new System.Windows.Forms.CheckBox();
             this.cbVulkSpiceLZ = new System.Windows.Forms.CheckBox();
+            this.cbReachability = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cbGoalMalak = new System.Windows.Forms.CheckBox();
+            this.cbGoalStarMaps = new System.Windows.Forms.CheckBox();
+            this.cbGoalPazaak = new System.Windows.Forms.CheckBox();
+            this.cbGlitchDlz = new System.Windows.Forms.CheckBox();
+            this.cbGlitchFlu = new System.Windows.Forms.CheckBox();
+            this.cbGlitchGpw = new System.Windows.Forms.CheckBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.ModulesToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.cbGlitchClip = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // OmittedListBox
@@ -98,6 +112,7 @@
             this.cbDeleteMilestones.Size = new System.Drawing.Size(159, 17);
             this.cbDeleteMilestones.TabIndex = 19;
             this.cbDeleteMilestones.Text = "Delete Milestone Save Data";
+            this.ModulesToolTip.SetToolTip(this.cbDeleteMilestones, resources.GetString("cbDeleteMilestones.ToolTip"));
             this.cbDeleteMilestones.UseVisualStyleBackColor = true;
             this.cbDeleteMilestones.CheckedChanged += new System.EventHandler(this.cbDeleteMilestones_CheckedChanged);
             // 
@@ -121,6 +136,8 @@
             this.cbSaveAllMods.Size = new System.Drawing.Size(157, 17);
             this.cbSaveAllMods.TabIndex = 21;
             this.cbSaveAllMods.Text = "Include All Modules in Save";
+            this.ModulesToolTip.SetToolTip(this.cbSaveAllMods, "This feature extends the minigame one to also include\r\nSTUNT cutscenes and variou" +
+        "s other odd modules in the\r\nsave file.");
             this.cbSaveAllMods.UseVisualStyleBackColor = true;
             this.cbSaveAllMods.CheckedChanged += new System.EventHandler(this.cbSaveAllMods_CheckedChanged);
             // 
@@ -133,6 +150,9 @@
             this.cbSaveMiniGame.Size = new System.Drawing.Size(153, 17);
             this.cbSaveMiniGame.TabIndex = 22;
             this.cbSaveMiniGame.Text = "Include Minigames in Save";
+            this.ModulesToolTip.SetToolTip(this.cbSaveMiniGame, "This feature makes the game commit the minigame module\r\ndata to the save when ent" +
+        "ering them, preventing possible\r\ngame crashes with randomized swoops or turrets." +
+        "");
             this.cbSaveMiniGame.UseVisualStyleBackColor = true;
             this.cbSaveMiniGame.CheckedChanged += new System.EventHandler(this.cbSaveMiniGame_CheckedChanged);
             // 
@@ -170,6 +190,7 @@
             this.cbFixDream.Size = new System.Drawing.Size(125, 17);
             this.cbFixDream.TabIndex = 25;
             this.cbFixDream.Text = "Fix Dream Sequence";
+            this.ModulesToolTip.SetToolTip(this.cbFixDream, "Fixes a rare instance in which a game crash could occur\r\nwith dream sequences.");
             this.cbFixDream.UseVisualStyleBackColor = true;
             this.cbFixDream.CheckedChanged += new System.EventHandler(this.cbFixDream_CheckedChanged);
             // 
@@ -182,6 +203,7 @@
             this.cbUnlockGalaxyMap.Size = new System.Drawing.Size(119, 17);
             this.cbUnlockGalaxyMap.TabIndex = 26;
             this.cbUnlockGalaxyMap.Text = "Unlock Galaxy Map";
+            this.ModulesToolTip.SetToolTip(this.cbUnlockGalaxyMap, "Unlock all destinations on the Ebon Hawk galaxy map from\r\nthe start of the game.");
             this.cbUnlockGalaxyMap.UseVisualStyleBackColor = true;
             this.cbUnlockGalaxyMap.CheckedChanged += new System.EventHandler(this.cbUnlockGalaxyMap_CheckedChanged);
             // 
@@ -194,6 +216,7 @@
             this.cbFixCoordinates.Size = new System.Drawing.Size(136, 17);
             this.cbFixCoordinates.TabIndex = 27;
             this.cbFixCoordinates.Text = "Fix Module Coordinates";
+            this.ModulesToolTip.SetToolTip(this.cbFixCoordinates, resources.GetString("cbFixCoordinates.ToolTip"));
             this.cbFixCoordinates.UseVisualStyleBackColor = true;
             this.cbFixCoordinates.CheckedChanged += new System.EventHandler(this.cbFixCoordinates_CheckedChanged);
             // 
@@ -206,6 +229,7 @@
             this.cbFixMindPrison.Size = new System.Drawing.Size(97, 17);
             this.cbFixMindPrison.TabIndex = 28;
             this.cbFixMindPrison.Text = "Fix Mind Prison";
+            this.ModulesToolTip.SetToolTip(this.cbFixMindPrison, "Updates the Mystery Box so it can be used multiple times.");
             this.cbFixMindPrison.UseVisualStyleBackColor = true;
             this.cbFixMindPrison.CheckedChanged += new System.EventHandler(this.cbFixMindPrison_CheckedChanged);
             // 
@@ -218,6 +242,8 @@
             this.cbDoorFix.Size = new System.Drawing.Size(129, 17);
             this.cbDoorFix.TabIndex = 29;
             this.cbDoorFix.Text = "Unlock Various Doors";
+            this.ModulesToolTip.SetToolTip(this.cbDoorFix, "Unlocks the door into the Dantooine Ruins and the door\r\nout of the Unknown World\'" +
+        "s Temple Summit.");
             this.cbDoorFix.UseVisualStyleBackColor = true;
             this.cbDoorFix.CheckedChanged += new System.EventHandler(this.cbDoorFix_CheckedChanged);
             // 
@@ -230,6 +256,8 @@
             this.cbFixLevElevators.Size = new System.Drawing.Size(136, 17);
             this.cbFixLevElevators.TabIndex = 30;
             this.cbFixLevElevators.Text = "Fix Leviathan Elevators";
+            this.ModulesToolTip.SetToolTip(this.cbFixLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hanger early, and" +
+        " the Hanger elevator is now usable.");
             this.cbFixLevElevators.UseVisualStyleBackColor = true;
             this.cbFixLevElevators.CheckedChanged += new System.EventHandler(this.cbFixLevElevators_CheckedChanged);
             // 
@@ -242,15 +270,172 @@
             this.cbVulkSpiceLZ.Size = new System.Drawing.Size(151, 17);
             this.cbVulkSpiceLZ.TabIndex = 31;
             this.cbVulkSpiceLZ.Text = "Add Spice Lab Load Zone";
+            this.ModulesToolTip.SetToolTip(this.cbVulkSpiceLZ, "A new loading zone to the unused Vulkar Spice Lab\r\nis added to the far west end o" +
+        "f the Vulkar Base.");
             this.cbVulkSpiceLZ.UseVisualStyleBackColor = true;
             this.cbVulkSpiceLZ.CheckedChanged += new System.EventHandler(this.cbVulkSpiceLZ_CheckedChanged);
+            // 
+            // cbReachability
+            // 
+            this.cbReachability.AutoSize = true;
+            this.cbReachability.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbReachability.Location = new System.Drawing.Point(20, 588);
+            this.cbReachability.Name = "cbReachability";
+            this.cbReachability.Size = new System.Drawing.Size(151, 17);
+            this.cbReachability.TabIndex = 32;
+            this.cbReachability.Text = "Verify Module Reachability";
+            this.ModulesToolTip.SetToolTip(this.cbReachability, "Reachability means that all modules leading up to\r\nand including the ones contain" +
+        "ing the goal(s) can\r\nbe found using either normal in-game logic or using\r\nthe gl" +
+        "itches enabled below.");
+            this.cbReachability.UseVisualStyleBackColor = true;
+            this.cbReachability.CheckedChanged += new System.EventHandler(this.cbReachability_CheckedChanged);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.label1.Location = new System.Drawing.Point(20, 612);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(132, 13);
+            this.label1.TabIndex = 33;
+            this.label1.Text = "Goal(s) of this playthrough:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.label2.Location = new System.Drawing.Point(20, 635);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(138, 13);
+            this.label2.TabIndex = 34;
+            this.label2.Text = "Potentially required glitches:";
+            // 
+            // cbGoalMalak
+            // 
+            this.cbGoalMalak.AutoSize = true;
+            this.cbGoalMalak.Checked = true;
+            this.cbGoalMalak.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbGoalMalak.Enabled = false;
+            this.cbGoalMalak.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGoalMalak.Location = new System.Drawing.Point(164, 611);
+            this.cbGoalMalak.Name = "cbGoalMalak";
+            this.cbGoalMalak.Size = new System.Drawing.Size(131, 17);
+            this.cbGoalMalak.TabIndex = 35;
+            this.cbGoalMalak.Text = "Defeat Malak (default)";
+            this.ModulesToolTip.SetToolTip(this.cbGoalMalak, "Defeat Malak on the Viewing Platform\r\nof the Star Forge.");
+            this.cbGoalMalak.UseVisualStyleBackColor = true;
+            this.cbGoalMalak.CheckedChanged += new System.EventHandler(this.cbGoalMalak_CheckedChanged);
+            // 
+            // cbGoalStarMaps
+            // 
+            this.cbGoalStarMaps.AutoSize = true;
+            this.cbGoalStarMaps.Enabled = false;
+            this.cbGoalStarMaps.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGoalStarMaps.Location = new System.Drawing.Point(301, 611);
+            this.cbGoalStarMaps.Name = "cbGoalStarMaps";
+            this.cbGoalStarMaps.Size = new System.Drawing.Size(109, 17);
+            this.cbGoalStarMaps.TabIndex = 36;
+            this.cbGoalStarMaps.Text = "Collect Star Maps";
+            this.ModulesToolTip.SetToolTip(this.cbGoalStarMaps, "Collect the 5 star maps from Dantooine,\r\nKashyyyk, Korriban, Manaan, and Tatooine" +
+        ".");
+            this.cbGoalStarMaps.UseVisualStyleBackColor = true;
+            this.cbGoalStarMaps.CheckedChanged += new System.EventHandler(this.cbGoalStarMaps_CheckedChanged);
+            // 
+            // cbGoalPazaak
+            // 
+            this.cbGoalPazaak.AutoSize = true;
+            this.cbGoalPazaak.Enabled = false;
+            this.cbGoalPazaak.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGoalPazaak.Location = new System.Drawing.Point(416, 611);
+            this.cbGoalPazaak.Name = "cbGoalPazaak";
+            this.cbGoalPazaak.Size = new System.Drawing.Size(112, 17);
+            this.cbGoalPazaak.TabIndex = 37;
+            this.cbGoalPazaak.Text = "Pazaak Champion";
+            this.ModulesToolTip.SetToolTip(this.cbGoalPazaak, "Defeat all pazaak players across the galaxy.");
+            this.cbGoalPazaak.UseVisualStyleBackColor = true;
+            this.cbGoalPazaak.CheckedChanged += new System.EventHandler(this.cbGoalPazaak_CheckedChanged);
+            // 
+            // cbGlitchDlz
+            // 
+            this.cbGlitchDlz.AutoSize = true;
+            this.cbGlitchDlz.Enabled = false;
+            this.cbGlitchDlz.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGlitchDlz.Location = new System.Drawing.Point(233, 634);
+            this.cbGlitchDlz.Name = "cbGlitchDlz";
+            this.cbGlitchDlz.Size = new System.Drawing.Size(47, 17);
+            this.cbGlitchDlz.TabIndex = 38;
+            this.cbGlitchDlz.Text = "DLZ";
+            this.ModulesToolTip.SetToolTip(this.cbGlitchDlz, "Displaced Loading Zone");
+            this.cbGlitchDlz.UseVisualStyleBackColor = true;
+            this.cbGlitchDlz.CheckedChanged += new System.EventHandler(this.cbGlitchDlz_CheckedChanged);
+            // 
+            // cbGlitchFlu
+            // 
+            this.cbGlitchFlu.AutoSize = true;
+            this.cbGlitchFlu.Enabled = false;
+            this.cbGlitchFlu.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGlitchFlu.Location = new System.Drawing.Point(286, 634);
+            this.cbGlitchFlu.Name = "cbGlitchFlu";
+            this.cbGlitchFlu.Size = new System.Drawing.Size(46, 17);
+            this.cbGlitchFlu.TabIndex = 39;
+            this.cbGlitchFlu.Text = "FLU";
+            this.ModulesToolTip.SetToolTip(this.cbGlitchFlu, "Fake Level Up");
+            this.cbGlitchFlu.UseVisualStyleBackColor = true;
+            this.cbGlitchFlu.CheckedChanged += new System.EventHandler(this.cbGlitchFlu_CheckedChanged);
+            // 
+            // cbGlitchGpw
+            // 
+            this.cbGlitchGpw.AutoSize = true;
+            this.cbGlitchGpw.Enabled = false;
+            this.cbGlitchGpw.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGlitchGpw.Location = new System.Drawing.Point(338, 634);
+            this.cbGlitchGpw.Name = "cbGlitchGpw";
+            this.cbGlitchGpw.Size = new System.Drawing.Size(52, 17);
+            this.cbGlitchGpw.TabIndex = 40;
+            this.cbGlitchGpw.Text = "GPW";
+            this.ModulesToolTip.SetToolTip(this.cbGlitchGpw, "Gather Party Warp / Teleport");
+            this.cbGlitchGpw.UseVisualStyleBackColor = true;
+            this.cbGlitchGpw.CheckedChanged += new System.EventHandler(this.cbGlitchGpw_CheckedChanged);
+            // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.panel1.Location = new System.Drawing.Point(20, 576);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(505, 2);
+            this.panel1.TabIndex = 41;
+            // 
+            // cbGlitchClip
+            // 
+            this.cbGlitchClip.AutoSize = true;
+            this.cbGlitchClip.Enabled = false;
+            this.cbGlitchClip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbGlitchClip.Location = new System.Drawing.Point(164, 634);
+            this.cbGlitchClip.Name = "cbGlitchClip";
+            this.cbGlitchClip.Size = new System.Drawing.Size(63, 17);
+            this.cbGlitchClip.TabIndex = 42;
+            this.cbGlitchClip.Text = "Clipping";
+            this.ModulesToolTip.SetToolTip(this.cbGlitchClip, "Clipping through doors, etc.");
+            this.cbGlitchClip.UseVisualStyleBackColor = true;
+            this.cbGlitchClip.CheckedChanged += new System.EventHandler(this.cbGlitchClip_CheckedChanged);
             // 
             // ModuleForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(541, 583);
+            this.ClientSize = new System.Drawing.Size(541, 667);
+            this.Controls.Add(this.cbGlitchClip);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.cbGlitchGpw);
+            this.Controls.Add(this.cbGlitchFlu);
+            this.Controls.Add(this.cbGlitchDlz);
+            this.Controls.Add(this.cbGoalPazaak);
+            this.Controls.Add(this.cbGoalStarMaps);
+            this.Controls.Add(this.cbGoalMalak);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.cbReachability);
             this.Controls.Add(this.cbVulkSpiceLZ);
             this.Controls.Add(this.cbFixLevElevators);
             this.Controls.Add(this.cbDoorFix);
@@ -297,5 +482,17 @@
         private System.Windows.Forms.CheckBox cbDoorFix;
         private System.Windows.Forms.CheckBox cbFixLevElevators;
         private System.Windows.Forms.CheckBox cbVulkSpiceLZ;
+        private System.Windows.Forms.CheckBox cbReachability;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.CheckBox cbGoalMalak;
+        private System.Windows.Forms.CheckBox cbGoalStarMaps;
+        private System.Windows.Forms.CheckBox cbGoalPazaak;
+        private System.Windows.Forms.CheckBox cbGlitchDlz;
+        private System.Windows.Forms.CheckBox cbGlitchFlu;
+        private System.Windows.Forms.CheckBox cbGlitchGpw;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.ToolTip ModulesToolTip;
+        private System.Windows.Forms.CheckBox cbGlitchClip;
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -53,6 +53,7 @@ namespace kotor_Randomizer_2
 
             // Initialize reachability settings
             cbReachability.Checked = settings.VerifyReachability;
+            cbIgnoreOnceEdges.Enabled = cbReachability.Checked;
             cbGoalMalak.Enabled = cbReachability.Checked;
             cbGoalStarMaps.Enabled = cbReachability.Checked;
             cbGoalPazaak.Enabled = cbReachability.Checked;
@@ -60,6 +61,7 @@ namespace kotor_Randomizer_2
             cbGlitchDlz.Enabled = cbReachability.Checked;
             cbGlitchFlu.Enabled = cbReachability.Checked;
             cbGlitchGpw.Enabled = cbReachability.Checked;
+            cbIgnoreOnceEdges.Checked = settings.IgnoreOnceEdges;
             cbGoalMalak.Checked = settings.GoalIsMalak;
             cbGoalStarMaps.Checked = settings.GoalIsStarMaps;
             cbGoalPazaak.Checked = settings.GoalIsPazaak;
@@ -293,6 +295,7 @@ namespace kotor_Randomizer_2
         {
             if (!Constructed) { return; }
             Properties.Settings.Default.VerifyReachability = cbReachability.Checked;
+            cbIgnoreOnceEdges.Enabled = cbReachability.Checked;
             cbGoalMalak.Enabled = cbReachability.Checked;
             cbGoalStarMaps.Enabled = cbReachability.Checked;
             cbGoalPazaak.Enabled = cbReachability.Checked;
@@ -342,6 +345,12 @@ namespace kotor_Randomizer_2
         {
             if (!Constructed) { return; }
             Properties.Settings.Default.AllowGlitchGpw = cbGlitchGpw.Checked;
+        }
+
+        private void cbAllowOnceEdges_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.IgnoreOnceEdges = cbIgnoreOnceEdges.Checked;
         }
 
         private void ModuleForm_Activated(object sender, EventArgs e)

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -51,6 +51,23 @@ namespace kotor_Randomizer_2
             cbFixLevElevators.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
             cbVulkSpiceLZ.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ);
 
+            // Initialize reachability settings
+            cbReachability.Checked = settings.VerifyReachability;
+            cbGoalMalak.Enabled = cbReachability.Checked;
+            cbGoalStarMaps.Enabled = cbReachability.Checked;
+            cbGoalPazaak.Enabled = cbReachability.Checked;
+            cbGlitchClip.Enabled = cbReachability.Checked;
+            cbGlitchDlz.Enabled = cbReachability.Checked;
+            cbGlitchFlu.Enabled = cbReachability.Checked;
+            cbGlitchGpw.Enabled = cbReachability.Checked;
+            cbGoalMalak.Checked = settings.GoalIsMalak;
+            cbGoalStarMaps.Checked = settings.GoalIsStarMaps;
+            cbGoalPazaak.Checked = settings.GoalIsPazaak;
+            cbGlitchClip.Checked = settings.AllowGlitchClip;
+            cbGlitchDlz.Checked = settings.AllowGlitchDlz;
+            cbGlitchFlu.Checked = settings.AllowGlitchFlu;
+            cbGlitchGpw.Checked = settings.AllowGlitchGpw;
+
             PresetComboBox.DataSource = Globals.OMIT_PRESETS.Keys.ToList();
             Constructed = true;
 
@@ -272,6 +289,61 @@ namespace kotor_Randomizer_2
             Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.VulkarSpiceLZ;
         }
 
+        private void cbReachability_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.VerifyReachability = cbReachability.Checked;
+            cbGoalMalak.Enabled = cbReachability.Checked;
+            cbGoalStarMaps.Enabled = cbReachability.Checked;
+            cbGoalPazaak.Enabled = cbReachability.Checked;
+            cbGlitchClip.Enabled = cbReachability.Checked;
+            cbGlitchDlz.Enabled = cbReachability.Checked;
+            cbGlitchFlu.Enabled = cbReachability.Checked;
+            cbGlitchGpw.Enabled = cbReachability.Checked;
+        }
+
+        private void cbGoalMalak_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.GoalIsMalak = cbGoalMalak.Checked;
+        }
+
+        private void cbGoalStarMaps_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.GoalIsStarMaps = cbGoalStarMaps.Checked;
+        }
+
+        private void cbGoalPazaak_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.GoalIsPazaak = cbGoalPazaak.Checked;
+        }
+
+        private void cbGlitchClip_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.AllowGlitchClip = cbGlitchClip.Checked;
+        }
+
+        private void cbGlitchDlz_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.AllowGlitchDlz = cbGlitchDlz.Checked;
+        }
+
+        private void cbGlitchFlu_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.AllowGlitchFlu = cbGlitchFlu.Checked;
+        }
+
+        private void cbGlitchGpw_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.AllowGlitchGpw = cbGlitchGpw.Checked;
+        }
+
         private void ModuleForm_Activated(object sender, EventArgs e)
         {
             if (Properties.Settings.Default.LastPresetComboIndex == -2)
@@ -294,9 +366,6 @@ namespace kotor_Randomizer_2
             }
         }
 
-
-
         #endregion
-
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -360,8 +360,9 @@ namespace kotor_Randomizer_2
                 Properties.Settings.Default.LastPresetComboIndex = -1;
                 PresetComboBox.SelectedIndex = -1;
                 UpdateListBoxes();
-
                 Constructed = false;
+
+                // Load new fix settings.
                 cbDeleteMilestones.Checked = !Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.NoSaveDelete);
                 cbSaveMiniGame.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.SaveMiniGames);
                 cbSaveAllMods.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.SaveAllModules);
@@ -371,6 +372,28 @@ namespace kotor_Randomizer_2
                 cbUnlockGalaxyMap.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
                 cbFixCoordinates.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates);
                 cbFixMindPrison.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
+                cbDoorFix.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
+                cbFixLevElevators.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
+
+                // Load new reachability settings.
+                cbReachability.Checked = Properties.Settings.Default.VerifyReachability;
+                cbIgnoreOnceEdges.Checked = Properties.Settings.Default.IgnoreOnceEdges;
+                cbGoalMalak.Checked = Properties.Settings.Default.GoalIsMalak;
+                cbGoalStarMaps.Checked = Properties.Settings.Default.GoalIsStarMaps;
+                cbGoalPazaak.Checked = Properties.Settings.Default.GoalIsPazaak;
+                cbGlitchClip.Checked = Properties.Settings.Default.AllowGlitchClip;
+                cbGlitchDlz.Checked = Properties.Settings.Default.AllowGlitchDlz;
+                cbGlitchFlu.Checked = Properties.Settings.Default.AllowGlitchFlu;
+                cbGlitchGpw.Checked = Properties.Settings.Default.AllowGlitchGpw;
+                cbIgnoreOnceEdges.Enabled = cbReachability.Checked;
+                cbGoalMalak.Enabled = cbReachability.Checked;
+                cbGoalStarMaps.Enabled = cbReachability.Checked;
+                cbGoalPazaak.Enabled = cbReachability.Checked;
+                cbGlitchClip.Enabled = cbReachability.Checked;
+                cbGlitchDlz.Enabled = cbReachability.Checked;
+                cbGlitchFlu.Enabled = cbReachability.Checked;
+                cbGlitchGpw.Enabled = cbReachability.Checked;
+
                 Constructed = true;
             }
         }

--- a/kotor Randomizer 2/Forms/ModuleForm.resx
+++ b/kotor Randomizer 2/Forms/ModuleForm.resx
@@ -117,4 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="cbDeleteMilestones.ToolTip" xml:space="preserve">
+    <value>Enabled by default in the base game. Unchecking will prevent
+the game clearing your save of presumed "unreachable" modules,
+such as Taris upon reaching Dantooine. Disabling this can help
+prevent loss of progress.</value>
+  </data>
+  <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="cbFixCoordinates.ToolTip" xml:space="preserve">
+    <value>Fixes the warp coordinates of several modules that would
+lead to potential softlocks otherwise: Undercity, Tulak Horde,
+Leviathan Hangar, Ahto West, Manaan Sith Base, Rakatan
+Settlement, and Temple Main Floor.</value>
+  </data>
 </root>

--- a/kotor Randomizer 2/Forms/ModuleForm.resx
+++ b/kotor Randomizer 2/Forms/ModuleForm.resx
@@ -126,12 +126,6 @@ the game clearing your save of presumed "unreachable" modules,
 such as Taris upon reaching Dantooine. Disabling this can help
 prevent loss of progress.</value>
   </data>
-  <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="cbFixCoordinates.ToolTip" xml:space="preserve">
     <value>Fixes the warp coordinates of several modules that would
 lead to potential softlocks otherwise: Undercity, Tulak Horde,

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -90,6 +90,17 @@ namespace kotor_Randomizer_2
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixLevElevators; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.VulkarSpiceLZ; }
 
+                        // Load reachability settings
+                        Properties.Settings.Default.VerifyReachability = br.ReadBoolean();
+                        Properties.Settings.Default.IgnoreOnceEdges = br.ReadBoolean();
+                        Properties.Settings.Default.AllowGlitchClip = br.ReadBoolean();
+                        Properties.Settings.Default.AllowGlitchDlz = br.ReadBoolean();
+                        Properties.Settings.Default.AllowGlitchFlu = br.ReadBoolean();
+                        Properties.Settings.Default.AllowGlitchGpw = br.ReadBoolean();
+                        Properties.Settings.Default.GoalIsMalak = br.ReadBoolean();
+                        Properties.Settings.Default.GoalIsPazaak = br.ReadBoolean();
+                        Properties.Settings.Default.GoalIsStarMaps = br.ReadBoolean();
+
                         Properties.Settings.Default.LastPresetComboIndex = -2;
                         Properties.Settings.Default.ModulePresetSelected = false;
                     }
@@ -338,6 +349,16 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors));   // Unlock Problem Doors
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators));  // Fixed Leviathan Elevators
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ));    // Add Vulkar Spice Loading Zone
+
+                    bw.Write(Properties.Settings.Default.VerifyReachability);   // 
+                    bw.Write(Properties.Settings.Default.IgnoreOnceEdges);      // 
+                    bw.Write(Properties.Settings.Default.AllowGlitchClip);      // 
+                    bw.Write(Properties.Settings.Default.AllowGlitchDlz);       // 
+                    bw.Write(Properties.Settings.Default.AllowGlitchFlu);       // 
+                    bw.Write(Properties.Settings.Default.AllowGlitchGpw);       // 
+                    bw.Write(Properties.Settings.Default.GoalIsMalak);          // 
+                    bw.Write(Properties.Settings.Default.GoalIsPazaak);         // 
+                    bw.Write(Properties.Settings.Default.GoalIsStarMaps);       //
                 }
                 // Items
                 if (Properties.Settings.Default.DoRandomization_Item)

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -926,5 +926,17 @@ namespace kotor_Randomizer_2.Properties {
                 this["AllowGlitchGpw"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool IgnoreOnceEdges {
+            get {
+                return ((bool)(this["IgnoreOnceEdges"]));
+            }
+            set {
+                this["IgnoreOnceEdges"] = value;
+            }
+        }
     }
 }

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace kotor_Randomizer_2.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -828,6 +828,102 @@ namespace kotor_Randomizer_2.Properties {
             }
             set {
                 this["RandomizePartyMembers"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool VerifyReachability {
+            get {
+                return ((bool)(this["VerifyReachability"]));
+            }
+            set {
+                this["VerifyReachability"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool GoalIsMalak {
+            get {
+                return ((bool)(this["GoalIsMalak"]));
+            }
+            set {
+                this["GoalIsMalak"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool GoalIsPazaak {
+            get {
+                return ((bool)(this["GoalIsPazaak"]));
+            }
+            set {
+                this["GoalIsPazaak"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool GoalIsStarMaps {
+            get {
+                return ((bool)(this["GoalIsStarMaps"]));
+            }
+            set {
+                this["GoalIsStarMaps"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AllowGlitchClip {
+            get {
+                return ((bool)(this["AllowGlitchClip"]));
+            }
+            set {
+                this["AllowGlitchClip"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AllowGlitchDlz {
+            get {
+                return ((bool)(this["AllowGlitchDlz"]));
+            }
+            set {
+                this["AllowGlitchDlz"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AllowGlitchFlu {
+            get {
+                return ((bool)(this["AllowGlitchFlu"]));
+            }
+            set {
+                this["AllowGlitchFlu"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AllowGlitchGpw {
+            get {
+                return ((bool)(this["AllowGlitchGpw"]));
+            }
+            set {
+                this["AllowGlitchGpw"] = value;
             }
         }
     }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -207,5 +207,29 @@
     <Setting Name="RandomizePartyMembers" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="VerifyReachability" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="GoalIsMalak" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="GoalIsPazaak" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="GoalIsStarMaps" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AllowGlitchClip" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AllowGlitchDlz" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AllowGlitchFlu" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AllowGlitchGpw" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -231,5 +231,8 @@
     <Setting Name="AllowGlitchGpw" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="IgnoreOnceEdges" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -60,7 +60,6 @@ namespace kotor_Randomizer_2
             // Split the Bound modules into their respective lists.
             List<string> ExcludedModules = Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Name).ToList();
             List<string> IncludedModules = Globals.BoundModules.Where(x => !x.Omitted).Select(x => x.Name).ToList();
-            Dictionary<string, string> LookupTable = new Dictionary<string, string>();  // Create lookup table to find a given module's new "name".
             bool reachable = false;
             int iterations = 0;
 
@@ -453,6 +452,17 @@ namespace kotor_Randomizer_2
                 sw.WriteLine($"Unlock Various Doors,{Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors)}");
                 sw.WriteLine($"Fix Leviathan Elevators,{Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators)}");
                 sw.WriteLine($"Add Spice Lab Load Zone,{Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ)}");
+                sw.WriteLine();
+
+                sw.WriteLine($"Verify Reachability,{!Properties.Settings.Default.VerifyReachability}");
+                sw.WriteLine($"Ignore Single-Use Transitions,{Properties.Settings.Default.IgnoreOnceEdges}");
+                sw.WriteLine($"Goal Is Malak,{Properties.Settings.Default.GoalIsMalak}");
+                sw.WriteLine($"Goal Is Star Maps,{Properties.Settings.Default.GoalIsStarMaps}");
+                sw.WriteLine($"Goal Is Pazaak,{Properties.Settings.Default.GoalIsPazaak}");
+                sw.WriteLine($"Allow Glitch Clipping,{Properties.Settings.Default.AllowGlitchClip}");
+                sw.WriteLine($"Allow Glitch DLZ,{Properties.Settings.Default.AllowGlitchDlz}");
+                sw.WriteLine($"Allow Glitch FLU,{Properties.Settings.Default.AllowGlitchFlu}");
+                sw.WriteLine($"Allow Glitch GPW,{Properties.Settings.Default.AllowGlitchGpw}");
                 sw.WriteLine();
 
                 sw.WriteLine("Has Changed,Original,Randomized");

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -29,6 +29,8 @@ namespace kotor_Randomizer_2
         private const string FIXED_DREAM_OVERRIDE = "k_ren_visionland.ncs";
         private const string UNLOCK_MAP_OVERRIDE = "k_pebn_galaxy.ncs";
 
+        private const int MAX_ITERATIONS = 10;
+
         /// <summary>
         /// A lookup table used to know how the modules are randomized.
         /// </summary>
@@ -58,28 +60,91 @@ namespace kotor_Randomizer_2
             // Split the Bound modules into their respective lists.
             List<string> ExcludedModules = Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Name).ToList();
             List<string> IncludedModules = Globals.BoundModules.Where(x => !x.Omitted).Select(x => x.Name).ToList();
+            Dictionary<string, string> LookupTable = new Dictionary<string, string>();  // Create lookup table to find a given module's new "name".
+            bool reachable = true;
+            int iterations = 0;
 
-            // Shuffle the list of included modules.
-            List<string> ShuffledModules = IncludedModules.ToList();
-            Randomize.FisherYatesShuffle(ShuffledModules);
+            // ------------------------------------------------------------
+
+            if (Properties.Settings.Default.VerifyReachability)
+            {
+                // Construct digraph and initialize reachability settings.
+                ModuleDigraph digraph = new ModuleDigraph(Path.Combine(Environment.CurrentDirectory, "Xml", "KotorModules.xml"));
+
+                System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+                sw.Start();
+
+                do
+                {
+                    iterations++;
+
+                    // Shuffle the list of included modules.
+                    List<string> ShuffledModules = IncludedModules.ToList();
+                    Randomize.FisherYatesShuffle(ShuffledModules);
+                    LookupTable.Clear();
+
+                    for (int i = 0; i < IncludedModules.Count; i++)
+                    {
+                        LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
+                    }
+
+                    foreach (string name in ExcludedModules)
+                    {
+                        LookupTable.Add(name, name);
+                    }
+
+                    digraph.SetRandomizationLookup(LookupTable);
+                    digraph.CheckReachability();
+                    reachable = digraph.IsGoalReachable();
+                } while (!reachable && iterations < MAX_ITERATIONS);
+
+                if (reachable) Console.WriteLine($"Reachable solution found after {iterations} shuffles. Time elapsed: {sw.Elapsed}");
+                else Console.WriteLine($"No reachable solution found over {iterations} shuffles. Time elapsed: {sw.Elapsed}");
+            }
+            else
+            {
+                // Shuffle the list of included modules.
+                List<string> ShuffledModules = IncludedModules.ToList();
+                Randomize.FisherYatesShuffle(ShuffledModules);
+                LookupTable.Clear();
+
+                for (int i = 0; i < IncludedModules.Count; i++)
+                {
+                    LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
+                }
+
+                foreach (string name in ExcludedModules)
+                {
+                    LookupTable.Add(name, name);
+                }
+            }
+
+            // ------------------------------------------------------------
 
             // Copy shuffled modules into the base directory.
-            for (int i = 0; i < IncludedModules.Count; i++)
+            foreach (var name in LookupTable)
             {
-                LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
-                File.Copy($"{paths.modules_backup}{IncludedModules[i]}.rim",   $"{paths.modules}{ShuffledModules[i]}.rim",   true);
-                File.Copy($"{paths.modules_backup}{IncludedModules[i]}_s.rim", $"{paths.modules}{ShuffledModules[i]}_s.rim", true);
-                File.Copy($"{paths.lips_backup}{IncludedModules[i]}_loc.mod",  $"{paths.lips}{ShuffledModules[i]}_loc.mod",  true);
+                File.Copy($"{paths.modules_backup}{name.Key}.rim",   $"{paths.modules}{name.Value}.rim",   true);
+                File.Copy($"{paths.modules_backup}{name.Key}_s.rim", $"{paths.modules}{name.Value}_s.rim", true);
+                File.Copy($"{paths.lips_backup}{name.Key}_loc.mod",  $"{paths.lips}{name.Value}_loc.mod",  true);
             }
 
-            // Copy excluded, untouched modules into the base directory.
-            foreach (string name in ExcludedModules)
-            {
-                LookupTable.Add(name, name);
-                File.Copy($"{paths.modules_backup}{name}.rim",   $"{paths.modules}{name}.rim",   true);
-                File.Copy($"{paths.modules_backup}{name}_s.rim", $"{paths.modules}{name}_s.rim", true);
-                File.Copy($"{paths.lips_backup}{name}_loc.mod",  $"{paths.lips}{name}_loc.mod",  true);
-            }
+            //for (int i = 0; i < IncludedModules.Count; i++)
+            //{
+            //    //LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
+            //    File.Copy($"{paths.modules_backup}{IncludedModules[i]}.rim",   $"{paths.modules}{ShuffledModules[i]}.rim",   true);
+            //    File.Copy($"{paths.modules_backup}{IncludedModules[i]}_s.rim", $"{paths.modules}{ShuffledModules[i]}_s.rim", true);
+            //    File.Copy($"{paths.lips_backup}{IncludedModules[i]}_loc.mod",  $"{paths.lips}{ShuffledModules[i]}_loc.mod",  true);
+            //}
+
+            //// Copy excluded, untouched modules into the base directory.
+            //foreach (string name in ExcludedModules)
+            //{
+            //    //LookupTable.Add(name, name);
+            //    File.Copy($"{paths.modules_backup}{name}.rim",   $"{paths.modules}{name}.rim",   true);
+            //    File.Copy($"{paths.modules_backup}{name}_s.rim", $"{paths.modules}{name}_s.rim", true);
+            //    File.Copy($"{paths.lips_backup}{name}_loc.mod",  $"{paths.lips}{name}_loc.mod",  true);
+            //}
 
             // Copy lips extras into the base directory.
             foreach (string name in Globals.lipXtras)

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -55,92 +55,102 @@ namespace kotor_Randomizer_2
                 Randomize.SetSeed(Properties.Settings.Default.Seed);    // Not sure when is the best time to set the seed.
 
                 // Randomize the categories.
-                if (Properties.Settings.Default.DoRandomization_Module)
+                try
                 {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingModules;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateModuleBackups();
-                    ModuleRando.Module_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogModulesDone);
-                    curr_progress += step_size;
+                    if (Properties.Settings.Default.DoRandomization_Module)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingModules;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateModuleBackups();
+                        ModuleRando.Module_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogModulesDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Item)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingItems;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateItemBackups();
+                        ItemRando.item_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogItemsDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Sound)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingMusicSound;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateSoundBackups();
+                        SoundRando.sound_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogMusicSoundDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Model)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingModels;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateModelBackups();
+                        ModelRando.model_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogModelsDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Texture)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingTextures;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateTextureBackups();
+                        TextureRando.texture_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogTexturesDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_TwoDA)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.Randomizing2DA;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateTwoDABackups();
+                        TwodaRandom.Twoda_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.Log2DADone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Text)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingText;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateTextBackups();
+                        TextRando.text_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogTextDone);
+                        curr_progress += step_size;
+                    }
+                    if (Properties.Settings.Default.DoRandomization_Other)
+                    {
+                        Randomize.RestartRng();
+                        curr_task = Properties.Resources.RandomizingOther;
+                        bwRandomizing.ReportProgress(curr_progress);
+                        CreateOtherBackups();
+                        OtherRando.other_rando(paths); // Run appropriate rando script.
+                        sw.WriteLine(Properties.Resources.LogOtherDone);
+                        curr_progress += step_size;
+                    }
                 }
-                if (Properties.Settings.Default.DoRandomization_Item)
+                catch (Exception e)
                 {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingItems;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateItemBackups();
-                    ItemRando.item_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogItemsDone);
-                    curr_progress += step_size;
+                    // Catch any randomization errors (e.g., reachability failure) and print a message.
+                    MessageBox.Show($"Error encountered during randomization: {Environment.NewLine}{e.Message}", "Randomization Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
-                if (Properties.Settings.Default.DoRandomization_Sound)
+                finally
                 {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingMusicSound;
+                    // Creates a basic log file with a date, version, and things done.
+                    curr_task = Properties.Resources.TaskFinishing;
                     bwRandomizing.ReportProgress(curr_progress);
-                    CreateSoundBackups();
-                    SoundRando.sound_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogMusicSoundDone);
-                    curr_progress += step_size;
+                    sw.WriteLine("\nThe Kotor Randomizer was created by Lane Dibello, with help from Glasnonck, and the greater Kotor Speedrunning community.");
+                    sw.WriteLine("If you encounter any issues please try to contact me @Lane#5847 on Discord");
                 }
-                if (Properties.Settings.Default.DoRandomization_Model)
-                {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingModels;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateModelBackups();
-                    ModelRando.model_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogModelsDone);
-                    curr_progress += step_size;
-                }
-                if (Properties.Settings.Default.DoRandomization_Texture)
-                {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingTextures;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateTextureBackups();
-                    TextureRando.texture_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogTexturesDone);
-                    curr_progress += step_size;
-                }
-                if (Properties.Settings.Default.DoRandomization_TwoDA)
-                {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.Randomizing2DA;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateTwoDABackups();
-                    TwodaRandom.Twoda_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.Log2DADone);
-                    curr_progress += step_size;
-                }
-                if (Properties.Settings.Default.DoRandomization_Text)
-                {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingText;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateTextBackups();
-                    TextRando.text_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogTextDone);
-                    curr_progress += step_size;
-                }
-                if (Properties.Settings.Default.DoRandomization_Other)
-                {
-                    Randomize.RestartRng();
-                    curr_task = Properties.Resources.RandomizingOther;
-                    bwRandomizing.ReportProgress(curr_progress);
-                    CreateOtherBackups();
-                    OtherRando.other_rando(paths); // Run appropriate rando script.
-                    sw.WriteLine(Properties.Resources.LogOtherDone);
-                    curr_progress += step_size;
-                }
-
-                // Creates a basic log file with a date, version, and things done.
-                curr_task = Properties.Resources.TaskFinishing;
-                bwRandomizing.ReportProgress(curr_progress);
-                sw.WriteLine("\nThe Kotor Randomizer was created by Lane Dibello, with help from Glasnonck, and the greater Kotor Speedrunning community.");
-                sw.WriteLine("If you encounter any issues please try to contact me @Lane#5847 on Discord");
             }
             curr_progress += step_size;
         }

--- a/kotor Randomizer 2/Resources/help/ModuleHelp.txt
+++ b/kotor Randomizer 2/Resources/help/ModuleHelp.txt
@@ -7,7 +7,7 @@ Omitted - This list box contains the resource reference codes for all of the mod
 Presets - This combo box contains a few hard coded presets for module randomization.
 
 Delete Module Save Data - This is enabled by default in the base game. Unchecking this will prevent the game of clearing the save file of presumably "unreachable" modules, such as Taris upon reaching Dantooine or the mid-game upon reaching Lehon. Disabling this can help prevent loss of progress.
-	Include Minigames in Save - This feature makes the game commit the minigame module data to the save when entering them, preventing possible game scrashes with randomized swoops or turrets.
+	Include Minigames in Save - This feature makes the game commit the minigame module data to the save when entering them, preventing possible game crashes with randomized swoops or turrets.
 
 Include All Modules in Save - This feature extends the previous one to also include STUNT cutscenes and various other odd modules in the save file.
 

--- a/kotor Randomizer 2/Xml/KotorModules.xml
+++ b/kotor Randomizer 2/Xml/KotorModules.xml
@@ -36,28 +36,32 @@
 
   <!--Ebon Hawk-->
   <Module WarpCode="ebo_m12aa" CommonName="Ebon Hawk">
-    <!--TODO: Find a good way to handle the map accessibility. Extra locations should be locked.-->
-    <LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" Tags="FixMap" />
-    <LeadsTo WarpCode="kas_m22aa" CommonName="Czerka Landing Port" Tags="FixMap" />
-    <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="FixMap" />
-    <LeadsTo WarpCode="manm26ad" CommonName="Manaan Docking Bay" Tags="FixMap" />
-    <LeadsTo WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay" Tags="FixMap" />
-    <LeadsTo WarpCode="liv_m99aa" CommonName="Yavin Station" Tags="FixMap" />
-    <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" Tags="FixMap" />
-    <LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" Tags="Locked,FixMap" />
+    <!--General-->
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Locked,FixMap" Unlock="tar_m08aa;danm13,danm15" />
+    <!--Obtain Hawk-->
+    <LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" Tags="Locked,FixMap" Unlock="tar_m08aa;danm13,danm15" />
+    <!--Dantooine Map-->
+    <LeadsTo WarpCode="kas_m22aa" CommonName="Czerka Landing Port" Tags="Locked,FixMap" Unlock="danm13,danm15" />
+    <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="Locked,FixMap" Unlock="danm13,danm15" />
     <LeadsTo WarpCode="ebo_m46ab" CommonName="Mystery Box" Tags="Once,Locked,FixBox" Unlock="korr_m33aa" />
-    <LeadsTo WarpCode="STUNT_12" CommonName="Calo Nord is Alive" Tags="Once" />
-    <LeadsTo WarpCode="STUNT_14" CommonName="Darth Bandon Recruited" Tags="Once" />
-    <LeadsTo WarpCode="STUNT_16" CommonName="Leviathan Captured (Old Mentor)" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />
-    <!--<LeadsTo WarpCode="lev_m40aa"  CommonName="Prison Block" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />-->
-    <LeadsTo WarpCode="STUNT_18" CommonName="Bastila is Tortured" Tags="Once,Locked" />
+    <LeadsTo WarpCode="manm26ad" CommonName="Manaan Docking Bay" Tags="Locked,FixMap" Unlock="danm13,danm15" />
+    <LeadsTo WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay" Tags="Locked,FixMap" Unlock="danm13,danm15" />
+    <LeadsTo WarpCode="liv_m99aa" CommonName="Yavin Station" Tags="Locked,FixMap" Unlock="danm13,danm15" />
+    <LeadsTo WarpCode="STUNT_12" CommonName="Calo Nord is Alive" Tags="Once,Locked" Unlock="danm13,danm15" />
+    <!--Two Extra Maps-->
+    <LeadsTo WarpCode="STUNT_14" CommonName="Darth Bandon Recruited" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa;kas_m25aa,manm28ad;kas_m25aa,tat_m18ac;korr_m39aa,manm28ad;korr_m39aa,tat_m18ac;manm28ad,tat_m18ac" />
+    <!--Three Extra Maps-->
+    <LeadsTo WarpCode="STUNT_16" CommonName="Leviathan Captured (Old Mentor)" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad;kas_m25aa,korr_m39aa,tat_m18ac;kas_m25aa,manm28ad,tat_m18ac;korr_m39aa,manm28ad,tat_m18ac" />
+    <!--Four Extra Maps-->
+    <LeadsTo WarpCode="STUNT_18" CommonName="Bastila is Tortured" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />
+    <!--<LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" Tags="Locked,FixMap" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />-->
+    <LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" Tags="Locked,FixMap" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac,unk_m44ac" />
   </Module>
   <Module WarpCode="ebo_m41aa" CommonName="Lehon Hawk">
     <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
-    <!--<LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" Tags="Locked" />-->
-    <!--TODO: Doesn't this take you to a cutscene? But that CS takes you to the Hawk... which leads to Deck 1 -->
-    <LeadsTo WarpCode="STUNT_42" CommonName="Pre-Star Forge Cutscene (Light Side)" Tags="Once,Locked" />
-    <LeadsTo WarpCode="STUNT_44" CommonName="Pre-Star Forge Cutscene (Dark Side)" Tags="Once,Locked" />
+    <!--Find parts and disable force field-->
+    <LeadsTo WarpCode="STUNT_42" CommonName="Pre-Star Forge Cutscene (Light Side)" Tags="Once,Locked" Unlock="unk_m44aa,Parts" />
+    <LeadsTo WarpCode="STUNT_44" CommonName="Pre-Star Forge Cutscene (Dark Side)" Tags="Once,Locked" Unlock="unk_m44aa,Parts" />
   </Module>
   <Module WarpCode="ebo_m46ab" CommonName="Mystery Box">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,FixBox" />
@@ -160,10 +164,7 @@
     <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" Tags="Fake,Locked,FixElev" />
     <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" Tags="Fake,Locked,FixElev" />
     <LeadsTo WarpCode="STUNT_31b" CommonName="Revan Reveal" Tags="Once,Locked" Unlock="Bastila,Carth" />
-    <!--<LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Once,Locked" Unlock="Bastila,Carth" />-->
-    <LeadsTo WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan" Tags="Once,Locked,FLU" Unlock="Bastila,Carth" FluReq="Carth" />
-    <!--<LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,Locked,FLU" Unlock="Bastila,Carth" FluReq="Carth" />-->
-    <!--Unsure about the tags...-->
+    <LeadsTo WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan" Tags="Once,Locked" Unlock="Bastila,Carth" FluReq="Carth" />
   </Module>
   <Module WarpCode="lev_m40ad" CommonName="Leviathan Bridge">
     <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" />
@@ -403,7 +404,7 @@
     <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
     <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
   </Module>
-  <Module WarpCode="unk_m41ab" CommonName="South Beach">
+  <Module WarpCode="unk_m41ab" CommonName="South Beach" Tags="Parts">
     <LeadsTo WarpCode="unk_m42aa" CommonName="Elder Settlement" />
     <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
   </Module>
@@ -420,7 +421,7 @@
   <Module WarpCode="unk_m42aa" CommonName="Elder Settlement">
     <LeadsTo WarpCode="unk_m41ab" CommonName="South Beach" />
   </Module>
-  <Module WarpCode="unk_m43aa" CommonName="Rakatan Settlement">
+  <Module WarpCode="unk_m43aa" CommonName="Rakatan Settlement" Tags="Parts">
     <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
   </Module>
   <Module WarpCode="unk_m44aa" CommonName="Temple Main Floor">

--- a/kotor Randomizer 2/Xml/KotorModules.xml
+++ b/kotor Randomizer 2/Xml/KotorModules.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<Modules Game="Kotor">
-  <!--Regular Modules-->
-  <Module WarpCode="danm13" CommonName="Jedi Enclave" Tags="Pazaak">
+<Modules Game="Kotor1">
+  <!--Dantooine-->
+  <Module WarpCode="danm13" CommonName="Jedi Enclave" Tags="Pazaak" LockedTag="Juhani" Unlock="danm14ac,danm15">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
     <LeadsTo WarpCode="danm14aa"  CommonName="Courtyard" />
     <LeadsTo WarpCode="danm13"    CommonName="Jedi Enclave" Tags="Once" />
@@ -9,7 +9,7 @@
   <Module WarpCode="danm14aa" CommonName="Courtyard">
     <LeadsTo WarpCode="danm13"   CommonName="Jedi Enclave" />
     <LeadsTo WarpCode="danm14ab" CommonName="Matale Grounds" />
-    <LeadsTo WarpCode="danm15"   CommonName="Dantooine Ruins" Tags="Locked,DLZ" />
+    <LeadsTo WarpCode="danm15"   CommonName="Dantooine Ruins" Tags="Locked,DLZ,FixDoors" Unlock="danm13,danm14ac" />
   </Module>
   <Module WarpCode="danm14ab" CommonName="Matale Grounds">
     <LeadsTo WarpCode="danm14aa" CommonName="Courtyard" />
@@ -21,41 +21,57 @@
   </Module>
   <Module WarpCode="danm14ad" CommonName="Sandral Grounds">
     <LeadsTo WarpCode="danm14ac" CommonName="Grove" />
-    <LeadsTo WarpCode="danm16"   CommonName="Sandral Estate" Tags="Locked,DLZ" />
+    <LeadsTo WarpCode="danm16"   CommonName="Sandral Estate" Tags="Locked,DLZ" Unlock="danm13,danm14ac" />
     <LeadsTo WarpCode="danm14ae" CommonName="Crystal Caves" />
   </Module>
   <Module WarpCode="danm14ae" CommonName="Crystal Caves">
     <LeadsTo WarpCode="danm14ad" CommonName="Sandral Grounds" />
   </Module>
-  <Module WarpCode="danm15" CommonName="Dantooine Ruins" Tags="StarMap">
+  <Module WarpCode="danm15" CommonName="Dantooine Ruins" Tags="StarMap,Bastila">
     <LeadsTo WarpCode="danm14aa" CommonName="Courtyard" />
   </Module>
   <Module WarpCode="danm16" CommonName="Sandral Estate">
     <LeadsTo WarpCode="danm14ad" CommonName="Sandral Grounds" />
   </Module>
+
+  <!--Ebon Hawk-->
   <Module WarpCode="ebo_m12aa" CommonName="Ebon Hawk">
-    <LeadsTo WarpCode="tat_m17ab"  CommonName="Tatooine Docking Bay" Tags="FixMap" />
-    <LeadsTo WarpCode="manm26ad"   CommonName="Manaan Docking Bay" Tags="FixMap" />
-    <LeadsTo WarpCode="kas_m22aa"  CommonName="Czerka Landing Port" Tags="FixMap" />
-    <LeadsTo WarpCode="danm13"     CommonName="Jedi Enclave" Tags="FixMap" />
+    <!--TODO: Find a good way to handle the map accessibility. Extra locations should be locked.-->
+    <LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" Tags="FixMap" />
+    <LeadsTo WarpCode="kas_m22aa" CommonName="Czerka Landing Port" Tags="FixMap" />
     <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="FixMap" />
-    <LeadsTo WarpCode="liv_m99aa"  CommonName="Yavin Station" Tags="FixMap" />
-    <LeadsTo WarpCode="unk_m41aa"  CommonName="Central Beach" Tags="FixMap" />
-    <LeadsTo WarpCode="sta_m45aa"  CommonName="Deck 1" Tags="FixMap" />
-    <LeadsTo WarpCode="ebo_m46ab"  CommonName="Mystery Box" Tags="Once,Locked,FixBox" />
+    <LeadsTo WarpCode="manm26ad" CommonName="Manaan Docking Bay" Tags="FixMap" />
+    <LeadsTo WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay" Tags="FixMap" />
+    <LeadsTo WarpCode="liv_m99aa" CommonName="Yavin Station" Tags="FixMap" />
+    <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" Tags="FixMap" />
+    <LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" Tags="Locked,FixMap" />
+    <LeadsTo WarpCode="ebo_m46ab" CommonName="Mystery Box" Tags="Once,Locked,FixBox" Unlock="korr_m33aa" />
+    <LeadsTo WarpCode="STUNT_12" CommonName="Calo Nord is Alive" Tags="Once" />
+    <LeadsTo WarpCode="STUNT_14" CommonName="Darth Bandon Recruited" Tags="Once" />
+    <LeadsTo WarpCode="STUNT_16" CommonName="Leviathan Captured (Old Mentor)" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />
+    <!--<LeadsTo WarpCode="lev_m40aa"  CommonName="Prison Block" Tags="Once,Locked" Unlock="kas_m25aa,korr_m39aa,manm28ad,tat_m18ac" />-->
+    <LeadsTo WarpCode="STUNT_18" CommonName="Bastila is Tortured" Tags="Once,Locked" />
   </Module>
   <Module WarpCode="ebo_m41aa" CommonName="Lehon Hawk">
     <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
+    <!--<LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" Tags="Locked" />-->
+    <!--TODO: Doesn't this take you to a cutscene? But that CS takes you to the Hawk... which leads to Deck 1 -->
+    <LeadsTo WarpCode="STUNT_42" CommonName="Pre-Star Forge Cutscene (Light Side)" Tags="Once,Locked" />
+    <LeadsTo WarpCode="STUNT_44" CommonName="Pre-Star Forge Cutscene (Dark Side)" Tags="Once,Locked" />
   </Module>
   <Module WarpCode="ebo_m46ab" CommonName="Mystery Box">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,FixBox" />
   </Module>
+
+  <!--Endar Spire-->
   <Module WarpCode="end_m01aa" CommonName="Command Module" Tags="Start">
     <LeadsTo WarpCode="end_m01ab" CommonName="Starboard Section" />
   </Module>
   <Module WarpCode="end_m01ab" CommonName="Starboard Section">
     <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" />
   </Module>
+
+  <!--Kashyyyk-->
   <Module WarpCode="kas_m22aa" CommonName="Czerka Landing Port" Tags="Pazaak">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
     <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
@@ -65,13 +81,13 @@
     <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
     <LeadsTo WarpCode="kas_m24aa" CommonName="Upper Shadowlands" />
     <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once" />
-    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" Unlock="kas_m25aa,kas_m23ad" />
   </Module>
   <Module WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro">
     <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
     <LeadsTo WarpCode="kas_m23ab" CommonName="Woorwill's Home" />
     <LeadsTo WarpCode="kas_m23ac" CommonName="Worrroznor's Home" />
-    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Locked" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Locked" Unlock="kas_m25aa,kas_m23ad" />
   </Module>
   <Module WarpCode="kas_m23ab" CommonName="Woorwill's Home">
     <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
@@ -82,22 +98,24 @@
   <Module WarpCode="kas_m23ad" CommonName="Chieftain's Hall">
     <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
   </Module>
-  <Module WarpCode="kas_m24aa" CommonName="Upper Shadowlands">
+  <Module WarpCode="kas_m24aa" CommonName="Upper Shadowlands" Tags="Jolee">
     <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
     <LeadsTo WarpCode="kas_m25aa" CommonName="Lower Shadowlands" />
-    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" Unlock="kas_m25aa" />
   </Module>
   <Module WarpCode="kas_m25aa" CommonName="Lower Shadowlands" Tags="StarMap">
     <LeadsTo WarpCode="kas_m24aa" CommonName="Upper Shadowlands" />
   </Module>
+
+  <!--Korriban-->
   <Module WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="Pazaak">
     <LeadsTo WarpCode="ebo_m12aa"  CommonName="Ebon Hawk" />
-    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Once,Locked" />
+    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Once,Locked" Unlock="korr_m33ab" />
     <LeadsTo WarpCode="korr_m33ab" CommonName="Sith Academy Entrance" />
   </Module>
   <Module WarpCode="korr_m33ab" CommonName="Sith Academy Entrance">
     <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" />
-    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Locked" />
+    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Locked" Unlock="korr_m33aa" />
   </Module>
   <Module WarpCode="korr_m34aa" CommonName="Shyrack Caves">
     <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
@@ -105,7 +123,7 @@
   <Module WarpCode="korr_m35aa" CommonName="Sith Academy">
     <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
     <LeadsTo WarpCode="korr_m33ab" CommonName="Sith Academy Entrance" />
-    <LeadsTo WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" Tags="Once,Locked" />
+    <LeadsTo WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" Tags="Once,Locked" Unlock="korr_m36aa" />
   </Module>
   <Module WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords">
     <LeadsTo WarpCode="korr_m34aa" CommonName="Shyrack Caves" />
@@ -127,36 +145,44 @@
   <Module WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" Tags="StarMap">
     <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
   </Module>
+
+  <!--Leviathan-->
   <Module WarpCode="lev_m40aa" CommonName="Prison Block">
     <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" />
-    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked" />
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked,FixElev" Unlock="lev_m40ad" />
   </Module>
   <Module WarpCode="lev_m40ab" CommonName="Command Deck">
     <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" />
-    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked" />
-    <LeadsTo WarpCode="lev_m40ad" CommonName="Leviathan Bridge" Tags="FLU" />
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked,FixElev" Unlock="lev_m40ad" />
+    <LeadsTo WarpCode="lev_m40ad" CommonName="Leviathan Bridge" />
   </Module>
   <Module WarpCode="lev_m40ac" CommonName="Leviathan Hangar">
-    <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" Tags="Fake,FixElev" />
-    <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" Tags="Fake,FixElev" />
-    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Once,Locked" />
-    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,Locked,FLU" />
+    <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" Tags="Fake,Locked,FixElev" />
+    <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" Tags="Fake,Locked,FixElev" />
+    <LeadsTo WarpCode="STUNT_31b" CommonName="Revan Reveal" Tags="Once,Locked" Unlock="Bastila,Carth" />
+    <!--<LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Once,Locked" Unlock="Bastila,Carth" />-->
+    <LeadsTo WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan" Tags="Once,Locked,FLU" Unlock="Bastila,Carth" FluReq="Carth" />
+    <!--<LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,Locked,FLU" Unlock="Bastila,Carth" FluReq="Carth" />-->
     <!--Unsure about the tags...-->
   </Module>
   <Module WarpCode="lev_m40ad" CommonName="Leviathan Bridge">
     <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" />
   </Module>
+
+  <!--Yavin IV-->
   <Module WarpCode="liv_m99aa" CommonName="Yavin Station" Tags="Pazaak">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
+
+  <!--Manaan-->
   <Module WarpCode="manm26aa"  CommonName="Ahto West" Tags="Pazaak">
     <LeadsTo WarpCode="manm26ac"  CommonName="West Central" />
   </Module>
   <Module WarpCode="manm26ab" CommonName="Ahto East">
     <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
     <LeadsTo WarpCode="manm26mg" CommonName="Manaan Swoops" />
-    <LeadsTo WarpCode="manm27aa" CommonName="Manaan Sith Base" Tags="Locked" />
-    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" />
+    <LeadsTo WarpCode="manm27aa" CommonName="Manaan Sith Base" Tags="Locked" Unlock="manm26ae" />
+    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" Unlock="manm27aa" />
   </Module>
   <Module WarpCode="manm26ac" CommonName="West Central" Tags="Pazaak">
     <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
@@ -166,13 +192,13 @@
   <Module WarpCode="manm26ad" CommonName="Manaan Docking Bay">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
     <LeadsTo WarpCode="manm26ac"  CommonName="West Central" />
-    <LeadsTo WarpCode="manm27aa"  CommonName="Manaan Sith Base" Tags="Locked,FLU" />
+    <LeadsTo WarpCode="manm27aa"  CommonName="Manaan Sith Base" Tags="Locked,FLU" Unlock="manm26ae" />
   </Module>
   <Module WarpCode="manm26ae" CommonName="East Central">
     <LeadsTo WarpCode="manm26ac" CommonName="West Central" />
     <LeadsTo WarpCode="manm26ab" CommonName="Ahto East" />
-    <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" Tags="Locked" />
-    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" />
+    <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" Tags="Locked,Clip" Unlock="manm27aa" />
+    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" Unlock="manm28ad" />
   </Module>
   <Module WarpCode="manm26mg" CommonName="Manaan Swoops">
     <LeadsTo WarpCode="manm26ab" CommonName="Ahto East" />
@@ -183,20 +209,22 @@
   <Module WarpCode="manm28aa" CommonName="Hrakert Station">
     <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
     <LeadsTo WarpCode="manm28ab" CommonName="Sea Floor" />
-    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" />
+    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" Unlock="manm28ad" />
   </Module>
   <Module WarpCode="manm28ab" CommonName="Sea Floor">
     <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" />
     <LeadsTo WarpCode="manm28ac" CommonName="Kolto Control" />
   </Module>
   <Module WarpCode="manm28ac" CommonName="Kolto Control">
-    <LeadsTo WarpCode="manm28ab" CommonName="Sea Floor" Tags="Locked" />
-    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" />
+    <LeadsTo WarpCode="manm28ab" CommonName="Sea Floor" Tags="Locked" Unlock="manm28aa" />
+    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" Unlock="manm28aa" />
   </Module>
   <Module WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="StarMap">
     <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" />
     <LeadsTo WarpCode="manm28ac" CommonName="Kolto Control" />
   </Module>
+
+  <!--Star Forge-->
   <Module WarpCode="sta_m45aa" CommonName="Deck 1">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
     <LeadsTo WarpCode="sta_m45ab" CommonName="Deck 2" />
@@ -207,20 +235,26 @@
   </Module>
   <Module WarpCode="sta_m45ac" CommonName="Command Center">
     <LeadsTo WarpCode="sta_m45ab" CommonName="Deck 2" />
+    <LeadsTo WarpCode="STUNT_50a" CommonName="Green Squadron" Tags="Once" />
+    <LeadsTo WarpCode="STUNT_51a" CommonName="Bastila Destroys the Republic Fleet" Tags="Once" />
     <LeadsTo WarpCode="sta_m45ad" CommonName="Viewing Platform" />
   </Module>
-  <Module WarpCode="sta_m45ad" CommonName="Viewing Platform" Tags="Finish,Malak">
+  <Module WarpCode="sta_m45ad" CommonName="Viewing Platform" Tags="Malak">
     <LeadsTo WarpCode="sta_m45ac" CommonName="Command Center" />
+    <LeadsTo WarpCode="STUNT_54a" CommonName="The Republic is Doomed" Tags="Once" />
+    <LeadsTo WarpCode="STUNT_56a" CommonName="Star Forge Destroyed" Tags="Once" />
   </Module>
+
+  <!--Taris-->
   <Module WarpCode="tar_m02aa" CommonName="South Apartments">
     <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" />
     <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
   </Module>
-  <Module WarpCode="tar_m02ab" CommonName="Upper City North">
+  <Module WarpCode="tar_m02ab" CommonName="Upper City North" LockedTag="T3M4" Unlock="tar_m02ae,tar_m03ae,tar_m03af,tar_m03mg">
     <LeadsTo WarpCode="tar_m02ad" CommonName="North Apartments" />
     <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
-    <LeadsTo WarpCode="tar_m09aa" CommonName="Taris Sith Base" Tags="Locked,FLU,DLZ" />
+    <LeadsTo WarpCode="tar_m09aa" CommonName="Taris Sith Base" Tags="Locked,FLU,DLZ" Unlock="T3M4" />
   </Module>
   <Module WarpCode="tar_m02ac" CommonName="Upper City South">
     <LeadsTo WarpCode="tar_m02aa" CommonName="South Apartments" />
@@ -230,21 +264,22 @@
   <Module WarpCode="tar_m02ad" CommonName="North Apartments">
     <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
   </Module>
-  <Module WarpCode="tar_m02ae" CommonName="Upper City Cantina" Tags="Pazaak">
+  <Module WarpCode="tar_m02ae" CommonName="Upper City Cantina" Tags="Pazaak" LockedTag="Canderous" Unlock="tar_m09aa">
     <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
-    <LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" />
+    <LeadsTo WarpCode="STUNT_03a" CommonName="Malak Orders Taris Destroyed" Tags="Once,Locked" Unlock="tar_m09aa" />
+    <!--<LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" Unlock="tar_m09aa" />-->
   </Module>
-  <Module WarpCode="tar_m02af" CommonName="Hideout">
+  <Module WarpCode="tar_m02af" CommonName="Hideout" Tags="Carth">
     <LeadsTo WarpCode="tar_m02aa" CommonName="South Apartments" />
   </Module>
   <Module WarpCode="tar_m03aa" CommonName="Lower City">
     <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
     <LeadsTo WarpCode="tar_m03ab" CommonName="Lower City Apt West" />
     <LeadsTo WarpCode="tar_m03ad" CommonName="Lower City Apt East" />
-    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" Tags="Locked,FLU" />
+    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" Tags="Locked,FLU" Unlock="tar_m10aa" />
     <LeadsTo WarpCode="tar_m11aa" CommonName="Bek Base" />
     <LeadsTo WarpCode="tar_m03ae" CommonName="Javyar's Cantina" />
-    <LeadsTo WarpCode="tar_m04aa" CommonName="Undercity" Tags="Locked,FLU" />
+    <LeadsTo WarpCode="tar_m04aa" CommonName="Undercity" Tags="Locked,FLU" Unlock="tar_m11aa" />
   </Module>
   <Module WarpCode="tar_m03ab" CommonName="Lower City Apt West">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
@@ -252,31 +287,33 @@
   <Module WarpCode="tar_m03ad" CommonName="Lower City Apt East">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
   </Module>
-  <Module WarpCode="tar_m03ae" CommonName="Javyar's Cantina" Tags="Pazaak">
+  <Module WarpCode="tar_m03ae" CommonName="Javyar's Cantina" Tags="Pazaak" LockedTag="Canderous" Unlock="tar_m09aa">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
-    <LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" />
+    <LeadsTo WarpCode="STUNT_03a" CommonName="Malak Orders Taris Destroyed" Tags="Once,Locked" Unlock="tar_m09aa" />
+    <!--<LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" Unlock="tar_m09aa" />-->
   </Module>
   <Module WarpCode="tar_m03af" CommonName="Swoop Platform">
     <LeadsTo WarpCode="tar_m03mg" CommonName="Taris Swoops" />
-    <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" Tags="Locked" />
+    <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" Tags="Locked" Unlock="tar_m03af,tar_m03mg" />
   </Module>
   <Module WarpCode="tar_m03mg" CommonName="Taris Swoops">
     <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" />
   </Module>
-  <Module WarpCode="tar_m04aa" CommonName="Undercity">
+  <Module WarpCode="tar_m04aa" CommonName="Undercity" Tags="Mission">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
     <LeadsTo WarpCode="tar_m05aa" CommonName="Lower Sewers" />
   </Module>
-  <Module WarpCode="tar_m05aa" CommonName="Lower Sewers">
+  <Module WarpCode="tar_m05aa" CommonName="Lower Sewers" LockedTag="Zaalbar" Unlock="Mission">
     <LeadsTo WarpCode="tar_m04aa" CommonName="Undercity" />
-    <LeadsTo WarpCode="tar_m05ab" CommonName="Upper Sewers" Tags="Locked,DLZ" />
+    <LeadsTo WarpCode="tar_m05ab" CommonName="Upper Sewers" Tags="Locked,DLZ" Unlock="Mission" />
   </Module>
   <Module WarpCode="tar_m05ab" CommonName="Upper Sewers">
     <LeadsTo WarpCode="tar_m05aa" CommonName="Lower Sewers" />
     <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
   </Module>
   <Module WarpCode="tar_m08aa" CommonName="Davik's Estate">
-    <LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" />
+    <LeadsTo WarpCode="STUNT_06" CommonName="Taris Destruction Update" />
+    <!--<LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" />-->
   </Module>
   <Module WarpCode="tar_m09aa" CommonName="Taris Sith Base">
     <LeadsTo WarpCode="tar_m09ab" CommonName="Governor Office" />
@@ -289,25 +326,27 @@
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
     <LeadsTo WarpCode="tar_m05ab" CommonName="Upper Sewers" />
     <LeadsTo WarpCode="tar_m10ac" CommonName="Vulkar Garage" />
-    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" />
-    <LeadsTo WarpCode="" CommonName="Vulkar Spice Lab" Tags="Fake" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" Unlock="tar_m11ab" />
+    <LeadsTo WarpCode="tar_m10ab" CommonName="Vulkar Spice Lab" Tags="Locked,FixSpice" />
   </Module>
-  <Module WarpCode="tar_m10ab" CommonName="Vulkar Spice Lab" Tags="Unreachable">
+  <Module WarpCode="tar_m10ab" CommonName="Vulkar Spice Lab">
     <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
   </Module>
   <Module WarpCode="tar_m10ac" CommonName="Vulkar Garage">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" Tags="Once" />
     <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
-    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Locked" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Locked" Unlock="tar_m11ab" />
   </Module>
   <Module WarpCode="tar_m11aa" CommonName="Bek Base">
     <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
-    <LeadsTo WarpCode="tar_m11ab" CommonName="Gadon's Office" Tags="Locked,FLU,GPTP,DLZ" />
-    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" />
+    <LeadsTo WarpCode="tar_m11ab" CommonName="Gadon's Office" Tags="Locked,FLU,GPW,DLZ" Unlock="tar_m10ac" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" Unlock="tar_m10ac" />
   </Module>
   <Module WarpCode="tar_m11ab" CommonName="Gadon's Office">
     <LeadsTo WarpCode="tar_m11aa" CommonName="Bek Base" />
   </Module>
+
+  <!--Tatooine-->
   <Module WarpCode="tat_m17aa" CommonName="Anchorhead">
     <LeadsTo WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay" />
     <LeadsTo WarpCode="tat_m17ad" CommonName="Hunting Lodge" />
@@ -315,13 +354,13 @@
     <LeadsTo WarpCode="tat_m17ae" CommonName="Swoop Registration" />
     <LeadsTo WarpCode="tat_m17af" CommonName="Tatooine Cantina" />
     <LeadsTo WarpCode="tat_m17ac" CommonName="Droid Shop" />
-    <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" Tags="Locked" />
+    <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" Tags="Locked" Unlock="tat_m17ag" />
   </Module>
   <Module WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay">
     <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
     <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module WarpCode="tat_m17ac" CommonName="Droid Shop">
+  <Module WarpCode="tat_m17ac" CommonName="Droid Shop" Tags="HK47">
     <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
   <Module WarpCode="tat_m17ad" CommonName="Hunting Lodge" Tags="Pazaak">
@@ -342,12 +381,12 @@
   </Module>
   <Module WarpCode="tat_m18aa" CommonName="Dune Sea">
     <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
-    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked" />
+    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked,STP" Unlock="tat_m17ac,tat_m20aa" />
     <LeadsTo WarpCode="tat_m18ab" CommonName="Sand People Territory" />
   </Module>
   <Module WarpCode="tat_m18ab" CommonName="Sand People Territory">
     <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" />
-    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked" />
+    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked,STP" Unlock="tat_m17ac,tat_m20aa" />
     <LeadsTo WarpCode="tat_m20aa" CommonName="Sand People Enclave" />
   </Module>
   <Module WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="StarMap">
@@ -357,6 +396,8 @@
   <Module WarpCode="tat_m20aa" CommonName="Sand People Enclave">
     <LeadsTo WarpCode="tat_m18ab" CommonName="Sand People Territory" />
   </Module>
+
+  <!--Unknown World-->
   <Module WarpCode="unk_m41aa" CommonName="Central Beach">
     <LeadsTo WarpCode="ebo_m41aa" CommonName="Lehon Hawk" />
     <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
@@ -373,7 +414,8 @@
   <Module WarpCode="unk_m41ad" CommonName="Temple Exterior">
     <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
     <LeadsTo WarpCode="unk_m41ab" CommonName="South Beach" />
-    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,GPTP,DLZ" />
+    <LeadsTo WarpCode="STUNT_19" CommonName="Jaw Drop" Tags="Once,Locked" Unlock="unk_m42aa,unk_m43aa" />
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,Clip,GPW,DLZ" Unlock="STUNT_19" />
   </Module>
   <Module WarpCode="unk_m42aa" CommonName="Elder Settlement">
     <LeadsTo WarpCode="unk_m41ab" CommonName="South Beach" />
@@ -382,81 +424,95 @@
     <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
   </Module>
   <Module WarpCode="unk_m44aa" CommonName="Temple Main Floor">
-    <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
+    <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" Tags="Locked" Unlock="unk_m44ac" />
     <LeadsTo WarpCode="unk_m44ab" CommonName="Temple Catacombs" />
-    <LeadsTo WarpCode="unk_m44ac" CommonName="Temple Summit" Tags="Locked,GPTP,DLZ" />
+    <LeadsTo WarpCode="unk_m44ac" CommonName="Temple Summit" Tags="Locked,GPW,DLZ" Unlock="unk_m44ab" />
   </Module>
   <Module WarpCode="unk_m44ab" CommonName="Temple Catacombs">
     <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
   </Module>
   <Module WarpCode="unk_m44ac" CommonName="Temple Summit">
-    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,FixDoors" Unlock="Jolee" />
   </Module>
-  
-  <!--Cutscene Modules-->
-  <Module WarpCode="ebo_m40aa" CommonName="Leviathan Game-Plan Cutscene">
-  </Module>
-  <Module WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan">
-  </Module>
-  <Module WarpCode="M12ab"     CommonName="Fighter Skirmish">
-  </Module>
-  <Module WarpCode="STUNT_00"  CommonName="Dream Sequence">
-  </Module>
+
+  <!--Repeated Cutscenes-->
+  <Module WarpCode="M12ab" CommonName="Fighter Skirmish" />
+  <Module WarpCode="STUNT_00" CommonName="Dream Sequence" />
+
+  <!--Taris Cutscenes-->
   <Module WarpCode="STUNT_03a" CommonName="Malak Orders Taris Destroyed">
-    <!--Davik's Estate--> <!--works multiple times-->
+    <LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" />
   </Module>
-  <Module WarpCode="STUNT_06"  CommonName="Taris Destruction Update">
-    <!--Escaping Taris on the Ebon Hawk-->
+  <Module WarpCode="STUNT_06" CommonName="Taris Destruction Update">
+    <LeadsTo WarpCode="STUNT_07" CommonName="Escaping Taris on the Ebon Hawk" />
+    <!--LeadsTo danm13 (Return to EH)-->
   </Module>
-  <Module WarpCode="STUNT_07"  CommonName="Escaping Taris on the Ebon Hawk">
-    <!--Fighter Skirmish-->
+  <Module WarpCode="STUNT_07" CommonName="Escaping Taris on the Ebon Hawk">
+    <!--LeadsTo WarpCode="M12ab" CommonName="Fighter Skirmish"-->
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
-  <Module WarpCode="STUNT_12"  CommonName="Calo Nord is Alive">
-    <!--Ebon Hawk (ebo_m12aa)-->
+
+  <!--Leviathan Cutscenes-->
+  <Module WarpCode="STUNT_16" CommonName="Leviathan Captured (Old Mentor)">
+    <LeadsTo WarpCode="ebo_m40aa" CommonName="Leviathan Game-Plan Cutscene" />
   </Module>
-  <Module WarpCode="STUNT_14"  CommonName="Darth Bandon Recruited">
-    <!--Ebon Hawk (ebo_m12aa)-->
-  </Module>
-  <Module WarpCode="STUNT_16"  CommonName="Leviathan Captured (Old Mentor)">
-    <!--Leviathan Game-Plan Cutscene (ebo_m40aa)-->
-  </Module>
-  <Module WarpCode="STUNT_18"  CommonName="Bastila is Tortured">
-    <!--STUNT_34-->
-  </Module>
-  <Module WarpCode="STUNT_19"  CommonName="Jaw Drop">
-    <!--Temple Main Floor (unk_m44aa)-->
+  <Module WarpCode="ebo_m40aa" CommonName="Leviathan Game-Plan Cutscene">
+    <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" />
   </Module>
   <Module WarpCode="STUNT_31b" CommonName="Revan Reveal">
-    <!--Leviathan Hangar (lev_m40ac)-->
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" />
   </Module>
-  <Module WarpCode="STUNT_34"  CommonName="Star Forge Arrival">
-    <!--Fighter Encounter-->
+  <Module WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
-  <Module WarpCode="STUNT_35"  CommonName="Lehon Distruptor Field">
-    <!--Lehon Hawk (ebo_m41aa)-->
+
+  <!--Star Map Cutscenes-->
+  <Module WarpCode="STUNT_12" CommonName="Calo Nord is Alive">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
-  <Module WarpCode="STUNT_42"  CommonName="Pre-Star Forge Cutscene (Light Side)">
-    <!--Ebon Hawk-->
+  <Module WarpCode="STUNT_14" CommonName="Darth Bandon Recruited">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
-  <Module WarpCode="STUNT_44"  CommonName="Pre-Star Forge Cutscene (Dark Side)">
-    <!--Ebon Hawk-->
+
+  <!--Star Forge System Cutscenes-->
+  <Module WarpCode="STUNT_18" CommonName="Bastila is Tortured">
+    <LeadsTo WarpCode="STUNT_34" CommonName="Star Forge Arrival" />
+  </Module>
+  <Module WarpCode="STUNT_34" CommonName="Star Forge Arrival">
+    <LeadsTo WarpCode="STUNT_35" CommonName="Lehon Distruptor Field" />
+  </Module>
+  <Module WarpCode="STUNT_35" CommonName="Lehon Distruptor Field">
+    <LeadsTo WarpCode="ebo_m41aa" CommonName="Lehon Hawk" />
+  </Module>
+  <Module WarpCode="STUNT_19" CommonName="Jaw Drop">
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
+  </Module>
+  <Module WarpCode="STUNT_42" CommonName="Pre-Star Forge Cutscene (Light Side)">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+  </Module>
+  <Module WarpCode="STUNT_44" CommonName="Pre-Star Forge Cutscene (Dark Side)">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
   </Module>
   <Module WarpCode="STUNT_50a" CommonName="Green Squadron">
-    <!--SF - Command Center ()-->
+    <LeadsTo WarpCode="sta_m45ac" CommonName="Command Center" />
   </Module>
   <Module WarpCode="STUNT_51a" CommonName="Bastila Destroys the Republic Fleet">
-    <!--SF - Command Center ()-->
+    <LeadsTo WarpCode="sta_m45ac" CommonName="Command Center" />
   </Module>
+
+  <!--Dark Side Ending Cutscenes-->
   <Module WarpCode="STUNT_54a" CommonName="The Republic is Doomed">
-    <!--All Hail Lord Revan (STUNT_55a)-->
+    <LeadsTo WarpCode="STUNT_55a" CommonName="All Hail Lord Revan (Dark Credits)" />
   </Module>
   <Module WarpCode="STUNT_55a" CommonName="All Hail Lord Revan (Dark Credits)">
-    <!--End of game - Main Menu-->
+    <!--LeadsTo End of game - Main Menu-->
   </Module>
+
+  <!--Light Side Ending Cutscenes-->
   <Module WarpCode="STUNT_56a" CommonName="Star Forge Destroyed">
-    <!--The Sith are Defeated (STUNT_57)-->
+    <LeadsTo WarpCode="STUNT_57" CommonName="The Sith are Defeated (Light Credits)" />
   </Module>
-  <Module WarpCode="STUNT_57"  CommonName="The Sith are Defeated (Light Credits)">
-    <!--End of game - Main Menu-->
+  <Module WarpCode="STUNT_57" CommonName="The Sith are Defeated (Light Credits)">
+    <!--LeadsTo End of game - Main Menu-->
   </Module>
 </Modules>

--- a/kotor Randomizer 2/Xml/KotorModules.xml
+++ b/kotor Randomizer 2/Xml/KotorModules.xml
@@ -1,400 +1,462 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Modules Game="Kotor">
-  <Module CommonName="Jedi Enclave" WarpCode="danm13">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-    <LeadsTo CommonName="Courtyard" WarpCode="danm14aa" />
-    <LeadsTo CommonName="Jedi Enclave" WarpCode="danm13" />
-  </Module>
-  <Module CommonName="Courtyard" WarpCode="danm14aa">
-    <LeadsTo CommonName="Jedi Enclave" WarpCode="danm13" />
-    <LeadsTo CommonName="Matale Grounds" WarpCode="danm14ab" />
-    <LeadsTo CommonName="Dantooine Ruins" WarpCode="danm15" />
-  </Module>
-  <Module CommonName="Matale Grounds" WarpCode="danm14ab">
-    <LeadsTo CommonName="Courtyard" WarpCode="danm14aa" />
-    <LeadsTo CommonName="Grove" WarpCode="danm14ac" />
-  </Module>
-  <Module CommonName="Grove" WarpCode="danm14ac">
-    <LeadsTo CommonName="Matale Grounds" WarpCode="danm14ab" />
-    <LeadsTo CommonName="Sandral Grounds" WarpCode="danm14ad" />
+  <!--Regular Modules-->
+  <Module WarpCode="danm13" CommonName="Jedi Enclave" Tags="Pazaak">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="danm14aa"  CommonName="Courtyard" />
+    <LeadsTo WarpCode="danm13"    CommonName="Jedi Enclave" Tags="Once" />
+  </Module>
+  <Module WarpCode="danm14aa" CommonName="Courtyard">
+    <LeadsTo WarpCode="danm13"   CommonName="Jedi Enclave" />
+    <LeadsTo WarpCode="danm14ab" CommonName="Matale Grounds" />
+    <LeadsTo WarpCode="danm15"   CommonName="Dantooine Ruins" Tags="Locked,DLZ" />
+  </Module>
+  <Module WarpCode="danm14ab" CommonName="Matale Grounds">
+    <LeadsTo WarpCode="danm14aa" CommonName="Courtyard" />
+    <LeadsTo WarpCode="danm14ac" CommonName="Grove" />
+  </Module>
+  <Module WarpCode="danm14ac" CommonName="Grove">
+    <LeadsTo WarpCode="danm14ab" CommonName="Matale Grounds" />
+    <LeadsTo WarpCode="danm14ad" CommonName="Sandral Grounds" />
+  </Module>
+  <Module WarpCode="danm14ad" CommonName="Sandral Grounds">
+    <LeadsTo WarpCode="danm14ac" CommonName="Grove" />
+    <LeadsTo WarpCode="danm16"   CommonName="Sandral Estate" Tags="Locked,DLZ" />
+    <LeadsTo WarpCode="danm14ae" CommonName="Crystal Caves" />
+  </Module>
+  <Module WarpCode="danm14ae" CommonName="Crystal Caves">
+    <LeadsTo WarpCode="danm14ad" CommonName="Sandral Grounds" />
+  </Module>
+  <Module WarpCode="danm15" CommonName="Dantooine Ruins" Tags="StarMap">
+    <LeadsTo WarpCode="danm14aa" CommonName="Courtyard" />
+  </Module>
+  <Module WarpCode="danm16" CommonName="Sandral Estate">
+    <LeadsTo WarpCode="danm14ad" CommonName="Sandral Grounds" />
+  </Module>
+  <Module WarpCode="ebo_m12aa" CommonName="Ebon Hawk">
+    <LeadsTo WarpCode="tat_m17ab"  CommonName="Tatooine Docking Bay" Tags="FixMap" />
+    <LeadsTo WarpCode="manm26ad"   CommonName="Manaan Docking Bay" Tags="FixMap" />
+    <LeadsTo WarpCode="kas_m22aa"  CommonName="Czerka Landing Port" Tags="FixMap" />
+    <LeadsTo WarpCode="danm13"     CommonName="Jedi Enclave" Tags="FixMap" />
+    <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="FixMap" />
+    <LeadsTo WarpCode="liv_m99aa"  CommonName="Yavin Station" Tags="FixMap" />
+    <LeadsTo WarpCode="unk_m41aa"  CommonName="Central Beach" Tags="FixMap" />
+    <LeadsTo WarpCode="sta_m45aa"  CommonName="Deck 1" Tags="FixMap" />
+    <LeadsTo WarpCode="ebo_m46ab"  CommonName="Mystery Box" Tags="Once,Locked,FixBox" />
+  </Module>
+  <Module WarpCode="ebo_m41aa" CommonName="Lehon Hawk">
+    <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
+  </Module>
+  <Module WarpCode="ebo_m46ab" CommonName="Mystery Box">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,FixBox" />
+  </Module>
+  <Module WarpCode="end_m01aa" CommonName="Command Module" Tags="Start">
+    <LeadsTo WarpCode="end_m01ab" CommonName="Starboard Section" />
+  </Module>
+  <Module WarpCode="end_m01ab" CommonName="Starboard Section">
+    <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" />
+  </Module>
+  <Module WarpCode="kas_m22aa" CommonName="Czerka Landing Port" Tags="Pazaak">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
+  </Module>
+  <Module WarpCode="kas_m22ab" CommonName="Great Walkway">
+    <LeadsTo WarpCode="kas_m22aa" CommonName="Czerka Landing Port" />
+    <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
+    <LeadsTo WarpCode="kas_m24aa" CommonName="Upper Shadowlands" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro">
+    <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
+    <LeadsTo WarpCode="kas_m23ab" CommonName="Woorwill's Home" />
+    <LeadsTo WarpCode="kas_m23ac" CommonName="Worrroznor's Home" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Locked" />
+  </Module>
+  <Module WarpCode="kas_m23ab" CommonName="Woorwill's Home">
+    <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
+  </Module>
+  <Module WarpCode="kas_m23ac" CommonName="Worrroznor's Home">
+    <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
+  </Module>
+  <Module WarpCode="kas_m23ad" CommonName="Chieftain's Hall">
+    <LeadsTo WarpCode="kas_m23aa" CommonName="Village of Rwookrrorro" />
+  </Module>
+  <Module WarpCode="kas_m24aa" CommonName="Upper Shadowlands">
+    <LeadsTo WarpCode="kas_m22ab" CommonName="Great Walkway" />
+    <LeadsTo WarpCode="kas_m25aa" CommonName="Lower Shadowlands" />
+    <LeadsTo WarpCode="kas_m23ad" CommonName="Chieftain's Hall" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="kas_m25aa" CommonName="Lower Shadowlands" Tags="StarMap">
+    <LeadsTo WarpCode="kas_m24aa" CommonName="Upper Shadowlands" />
+  </Module>
+  <Module WarpCode="korr_m33aa" CommonName="Dreshdae" Tags="Pazaak">
+    <LeadsTo WarpCode="ebo_m12aa"  CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Once,Locked" />
+    <LeadsTo WarpCode="korr_m33ab" CommonName="Sith Academy Entrance" />
+  </Module>
+  <Module WarpCode="korr_m33ab" CommonName="Sith Academy Entrance">
+    <LeadsTo WarpCode="korr_m33aa" CommonName="Dreshdae" />
+    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" Tags="Locked" />
+  </Module>
+  <Module WarpCode="korr_m34aa" CommonName="Shyrack Caves">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+  </Module>
+  <Module WarpCode="korr_m35aa" CommonName="Sith Academy">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+    <LeadsTo WarpCode="korr_m33ab" CommonName="Sith Academy Entrance" />
+    <LeadsTo WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords">
+    <LeadsTo WarpCode="korr_m34aa" CommonName="Shyrack Caves" />
+    <LeadsTo WarpCode="korr_m35aa" CommonName="Sith Academy" />
+    <LeadsTo WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" />
+    <LeadsTo WarpCode="korr_m37aa" CommonName="Tomb of Ajunta Pall" />
+    <LeadsTo WarpCode="korr_m38aa" CommonName="Tomb of Marka Ragnos" />
+    <LeadsTo WarpCode="korr_m38ab" CommonName="Tomb of Tulak Hord" />
+  </Module>
+  <Module WarpCode="korr_m37aa" CommonName="Tomb of Ajunta Pall">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+  </Module>
+  <Module WarpCode="korr_m38aa" CommonName="Tomb of Marka Ragnos">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+  </Module>
+  <Module WarpCode="korr_m38ab" CommonName="Tomb of Tulak Hord">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+  </Module>
+  <Module WarpCode="korr_m39aa" CommonName="Tomb of Naga Sadow" Tags="StarMap">
+    <LeadsTo WarpCode="korr_m36aa" CommonName="Valley of the Dark Lords" />
+  </Module>
+  <Module WarpCode="lev_m40aa" CommonName="Prison Block">
+    <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" />
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked" />
+  </Module>
+  <Module WarpCode="lev_m40ab" CommonName="Command Deck">
+    <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" />
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Locked" />
+    <LeadsTo WarpCode="lev_m40ad" CommonName="Leviathan Bridge" Tags="FLU" />
+  </Module>
+  <Module WarpCode="lev_m40ac" CommonName="Leviathan Hangar">
+    <LeadsTo WarpCode="lev_m40aa" CommonName="Prison Block" Tags="Fake,FixElev" />
+    <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" Tags="Fake,FixElev" />
+    <LeadsTo WarpCode="lev_m40ac" CommonName="Leviathan Hangar" Tags="Once,Locked" />
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" Tags="Once,Locked,FLU" />
+    <!--Unsure about the tags...-->
+  </Module>
+  <Module WarpCode="lev_m40ad" CommonName="Leviathan Bridge">
+    <LeadsTo WarpCode="lev_m40ab" CommonName="Command Deck" />
+  </Module>
+  <Module WarpCode="liv_m99aa" CommonName="Yavin Station" Tags="Pazaak">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+  </Module>
+  <Module WarpCode="manm26aa"  CommonName="Ahto West" Tags="Pazaak">
+    <LeadsTo WarpCode="manm26ac"  CommonName="West Central" />
+  </Module>
+  <Module WarpCode="manm26ab" CommonName="Ahto East">
+    <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
+    <LeadsTo WarpCode="manm26mg" CommonName="Manaan Swoops" />
+    <LeadsTo WarpCode="manm27aa" CommonName="Manaan Sith Base" Tags="Locked" />
+    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="manm26ac" CommonName="West Central" Tags="Pazaak">
+    <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
+    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" />
+    <LeadsTo WarpCode="manm26ad" CommonName="Manaan Docking Bay" />
+  </Module>
+  <Module WarpCode="manm26ad" CommonName="Manaan Docking Bay">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="manm26ac"  CommonName="West Central" />
+    <LeadsTo WarpCode="manm27aa"  CommonName="Manaan Sith Base" Tags="Locked,FLU" />
+  </Module>
+  <Module WarpCode="manm26ae" CommonName="East Central">
+    <LeadsTo WarpCode="manm26ac" CommonName="West Central" />
+    <LeadsTo WarpCode="manm26ab" CommonName="Ahto East" />
+    <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" Tags="Locked" />
+    <LeadsTo WarpCode="manm26aa" CommonName="Ahto West" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="manm26mg" CommonName="Manaan Swoops">
+    <LeadsTo WarpCode="manm26ab" CommonName="Ahto East" />
+  </Module>
+  <Module WarpCode="manm27aa" CommonName="Manaan Sith Base">
+    <LeadsTo WarpCode="manm26ab" CommonName="Ahto East" />
+  </Module>
+  <Module WarpCode="manm28aa" CommonName="Hrakert Station">
+    <LeadsTo WarpCode="manm26ae" CommonName="East Central" />
+    <LeadsTo WarpCode="manm28ab" CommonName="Sea Floor" />
+    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" />
+  </Module>
+  <Module WarpCode="manm28ab" CommonName="Sea Floor">
+    <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" />
+    <LeadsTo WarpCode="manm28ac" CommonName="Kolto Control" />
+  </Module>
+  <Module WarpCode="manm28ac" CommonName="Kolto Control">
+    <LeadsTo WarpCode="manm28ab" CommonName="Sea Floor" Tags="Locked" />
+    <LeadsTo WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="Locked" />
+  </Module>
+  <Module WarpCode="manm28ad" CommonName="Hrakert Rift" Tags="StarMap">
+    <LeadsTo WarpCode="manm28aa" CommonName="Hrakert Station" />
+    <LeadsTo WarpCode="manm28ac" CommonName="Kolto Control" />
+  </Module>
+  <Module WarpCode="sta_m45aa" CommonName="Deck 1">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="sta_m45ab" CommonName="Deck 2" />
+  </Module>
+  <Module WarpCode="sta_m45ab" CommonName="Deck 2">
+    <LeadsTo WarpCode="sta_m45aa" CommonName="Deck 1" />
+    <LeadsTo WarpCode="sta_m45ac" CommonName="Command Center" />
+  </Module>
+  <Module WarpCode="sta_m45ac" CommonName="Command Center">
+    <LeadsTo WarpCode="sta_m45ab" CommonName="Deck 2" />
+    <LeadsTo WarpCode="sta_m45ad" CommonName="Viewing Platform" />
+  </Module>
+  <Module WarpCode="sta_m45ad" CommonName="Viewing Platform" Tags="Finish,Malak">
+    <LeadsTo WarpCode="sta_m45ac" CommonName="Command Center" />
+  </Module>
+  <Module WarpCode="tar_m02aa" CommonName="South Apartments">
+    <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" />
+    <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
+  </Module>
+  <Module WarpCode="tar_m02ab" CommonName="Upper City North">
+    <LeadsTo WarpCode="tar_m02ad" CommonName="North Apartments" />
+    <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+    <LeadsTo WarpCode="tar_m09aa" CommonName="Taris Sith Base" Tags="Locked,FLU,DLZ" />
+  </Module>
+  <Module WarpCode="tar_m02ac" CommonName="Upper City South">
+    <LeadsTo WarpCode="tar_m02aa" CommonName="South Apartments" />
+    <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
+    <LeadsTo WarpCode="tar_m02ae" CommonName="Upper City Cantina" />
+  </Module>
+  <Module WarpCode="tar_m02ad" CommonName="North Apartments">
+    <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
+  </Module>
+  <Module WarpCode="tar_m02ae" CommonName="Upper City Cantina" Tags="Pazaak">
+    <LeadsTo WarpCode="tar_m02ac" CommonName="Upper City South" />
+    <LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="tar_m02af" CommonName="Hideout">
+    <LeadsTo WarpCode="tar_m02aa" CommonName="South Apartments" />
+  </Module>
+  <Module WarpCode="tar_m03aa" CommonName="Lower City">
+    <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
+    <LeadsTo WarpCode="tar_m03ab" CommonName="Lower City Apt West" />
+    <LeadsTo WarpCode="tar_m03ad" CommonName="Lower City Apt East" />
+    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" Tags="Locked,FLU" />
+    <LeadsTo WarpCode="tar_m11aa" CommonName="Bek Base" />
+    <LeadsTo WarpCode="tar_m03ae" CommonName="Javyar's Cantina" />
+    <LeadsTo WarpCode="tar_m04aa" CommonName="Undercity" Tags="Locked,FLU" />
+  </Module>
+  <Module WarpCode="tar_m03ab" CommonName="Lower City Apt West">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+  </Module>
+  <Module WarpCode="tar_m03ad" CommonName="Lower City Apt East">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+  </Module>
+  <Module WarpCode="tar_m03ae" CommonName="Javyar's Cantina" Tags="Pazaak">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+    <LeadsTo WarpCode="tar_m08aa" CommonName="Davik's Estate" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="tar_m03af" CommonName="Swoop Platform">
+    <LeadsTo WarpCode="tar_m03mg" CommonName="Taris Swoops" />
+    <LeadsTo WarpCode="tar_m02af" CommonName="Hideout" Tags="Locked" />
+  </Module>
+  <Module WarpCode="tar_m03mg" CommonName="Taris Swoops">
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" />
+  </Module>
+  <Module WarpCode="tar_m04aa" CommonName="Undercity">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+    <LeadsTo WarpCode="tar_m05aa" CommonName="Lower Sewers" />
+  </Module>
+  <Module WarpCode="tar_m05aa" CommonName="Lower Sewers">
+    <LeadsTo WarpCode="tar_m04aa" CommonName="Undercity" />
+    <LeadsTo WarpCode="tar_m05ab" CommonName="Upper Sewers" Tags="Locked,DLZ" />
+  </Module>
+  <Module WarpCode="tar_m05ab" CommonName="Upper Sewers">
+    <LeadsTo WarpCode="tar_m05aa" CommonName="Lower Sewers" />
+    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
+  </Module>
+  <Module WarpCode="tar_m08aa" CommonName="Davik's Estate">
+    <LeadsTo WarpCode="danm13" CommonName="Jedi Enclave" />
+  </Module>
+  <Module WarpCode="tar_m09aa" CommonName="Taris Sith Base">
+    <LeadsTo WarpCode="tar_m09ab" CommonName="Governor Office" />
+    <LeadsTo WarpCode="tar_m02ab" CommonName="Upper City North" />
+  </Module>
+  <Module WarpCode="tar_m09ab" CommonName="Governor Office">
+    <LeadsTo WarpCode="tar_m09aa" CommonName="Taris Sith Base" />
+  </Module>
+  <Module WarpCode="tar_m10aa" CommonName="Vulkar Base">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+    <LeadsTo WarpCode="tar_m05ab" CommonName="Upper Sewers" />
+    <LeadsTo WarpCode="tar_m10ac" CommonName="Vulkar Garage" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" />
+    <LeadsTo WarpCode="" CommonName="Vulkar Spice Lab" Tags="Fake" />
+  </Module>
+  <Module WarpCode="tar_m10ab" CommonName="Vulkar Spice Lab" Tags="Unreachable">
+    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
+  </Module>
+  <Module WarpCode="tar_m10ac" CommonName="Vulkar Garage">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" Tags="Once" />
+    <LeadsTo WarpCode="tar_m10aa" CommonName="Vulkar Base" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Locked" />
+  </Module>
+  <Module WarpCode="tar_m11aa" CommonName="Bek Base">
+    <LeadsTo WarpCode="tar_m03aa" CommonName="Lower City" />
+    <LeadsTo WarpCode="tar_m11ab" CommonName="Gadon's Office" Tags="Locked,FLU,GPTP,DLZ" />
+    <LeadsTo WarpCode="tar_m03af" CommonName="Swoop Platform" Tags="Once,Locked" />
+  </Module>
+  <Module WarpCode="tar_m11ab" CommonName="Gadon's Office">
+    <LeadsTo WarpCode="tar_m11aa" CommonName="Bek Base" />
+  </Module>
+  <Module WarpCode="tat_m17aa" CommonName="Anchorhead">
+    <LeadsTo WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay" />
+    <LeadsTo WarpCode="tat_m17ad" CommonName="Hunting Lodge" />
+    <LeadsTo WarpCode="tat_m17ag" CommonName="Czerka Office" />
+    <LeadsTo WarpCode="tat_m17ae" CommonName="Swoop Registration" />
+    <LeadsTo WarpCode="tat_m17af" CommonName="Tatooine Cantina" />
+    <LeadsTo WarpCode="tat_m17ac" CommonName="Droid Shop" />
+    <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" Tags="Locked" />
   </Module>
-  <Module CommonName="Sandral Grounds" WarpCode="danm14ad">
-    <LeadsTo CommonName="Grove" WarpCode="danm14ac" />
-    <LeadsTo CommonName="Sandral Estate" WarpCode="danm16" />
-    <LeadsTo CommonName="Crystal Caves" WarpCode="danm14ae" />
+  <Module WarpCode="tat_m17ab" CommonName="Tatooine Docking Bay">
+    <LeadsTo WarpCode="ebo_m12aa" CommonName="Ebon Hawk" />
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module CommonName="Crystal Caves" WarpCode="danm14ae">
-    <LeadsTo CommonName="Sandral Grounds" WarpCode="danm14ad" />
-  </Module>
-  <Module CommonName="Dantooine Ruins" WarpCode="danm15">
-    <LeadsTo CommonName="Courtyard" WarpCode="danm14aa" />
+  <Module WarpCode="tat_m17ac" CommonName="Droid Shop">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module CommonName="Sandral Estate" WarpCode="danm16">
-    <LeadsTo CommonName="Sandral Grounds" WarpCode="danm14ad" />
+  <Module WarpCode="tat_m17ad" CommonName="Hunting Lodge" Tags="Pazaak">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module CommonName="Ebon Hawk" WarpCode="ebo_m12aa">
-    <LeadsTo CommonName="k_current_planet" WarpCode="" />
+  <Module WarpCode="tat_m17ae" CommonName="Swoop Registration">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
+    <LeadsTo WarpCode="tat_m17mg" CommonName="Tatooine Swoops" />
   </Module>
-  <Module CommonName="Lehon Hawk" WarpCode="ebo_m41aa">
-    <LeadsTo CommonName="Central Beach" WarpCode="unk_m41aa" />
+  <Module WarpCode="tat_m17af" CommonName="Tatooine Cantina" Tags="Pazaak">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module CommonName="Mystery Box" WarpCode="ebo_m46ab">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
+  <Module WarpCode="tat_m17ag" CommonName="Czerka Office">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
   </Module>
-  <Module CommonName="Command Module" WarpCode="end_m01aa">
-    <LeadsTo CommonName="Starboard Section" WarpCode="end_m01ab" />
+  <Module WarpCode="tat_m17mg" CommonName="Tatooine Swoops">
+    <LeadsTo WarpCode="tat_m17ae" CommonName="Swoop Registration" />
   </Module>
-  <Module CommonName="Starboard Section" WarpCode="end_m01ab">
-    <LeadsTo CommonName="Hideout" WarpCode="tar_m02af" />
+  <Module WarpCode="tat_m18aa" CommonName="Dune Sea">
+    <LeadsTo WarpCode="tat_m17aa" CommonName="Anchorhead" />
+    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked" />
+    <LeadsTo WarpCode="tat_m18ab" CommonName="Sand People Territory" />
   </Module>
-  <Module CommonName="Czerka Landing Port" WarpCode="kas_m22aa">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-    <LeadsTo CommonName="Great Walkway" WarpCode="kas_m22ab" />
+  <Module WarpCode="tat_m18ab" CommonName="Sand People Territory">
+    <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" />
+    <LeadsTo WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="Locked" />
+    <LeadsTo WarpCode="tat_m20aa" CommonName="Sand People Enclave" />
   </Module>
-  <Module CommonName="Great Walkway" WarpCode="kas_m22ab">
-    <LeadsTo CommonName="Czerka Landing Port" WarpCode="kas_m22aa" />
-    <LeadsTo CommonName="Village of Rwookrrorro" WarpCode="kas_m23aa" />
-    <LeadsTo CommonName="Upper Shadowlands" WarpCode="kas_m24aa" />
-    <LeadsTo CommonName="Chieftain's Hall" WarpCode="kas_m23ad" />
+  <Module WarpCode="tat_m18ac" CommonName="Eastern Dune Sea" Tags="StarMap">
+    <LeadsTo WarpCode="tat_m18aa" CommonName="Dune Sea" />
+    <LeadsTo WarpCode="tat_m18ab" CommonName="Sand People Territory" />
   </Module>
-  <Module CommonName="Village of Rwookrrorro" WarpCode="kas_m23aa">
-    <LeadsTo CommonName="Great Walkway" WarpCode="kas_m22ab" />
-    <LeadsTo CommonName="Woorwill's Home" WarpCode="kas_m23ab" />
-    <LeadsTo CommonName="Worrroznor's Home" WarpCode="kas_m23ac" />
-    <LeadsTo CommonName="Chieftain's Hall" WarpCode="kas_m23ad" />
-  </Module>
-  <Module CommonName="Woorwill's Home" WarpCode="kas_m23ab">
-    <LeadsTo CommonName="Village of Rwookrrorro" WarpCode="kas_m23aa" />
-  </Module>
-  <Module CommonName="Worrroznor's Home" WarpCode="kas_m23ac">
-    <LeadsTo CommonName="Village of Rwookrrorro" WarpCode="kas_m23aa" />
+  <Module WarpCode="tat_m20aa" CommonName="Sand People Enclave">
+    <LeadsTo WarpCode="tat_m18ab" CommonName="Sand People Territory" />
   </Module>
-  <Module CommonName="Chieftain's Hall" WarpCode="kas_m23ad">
-    <LeadsTo CommonName="Village of Rwookrrorro" WarpCode="kas_m23aa" />
+  <Module WarpCode="unk_m41aa" CommonName="Central Beach">
+    <LeadsTo WarpCode="ebo_m41aa" CommonName="Lehon Hawk" />
+    <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
+    <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
   </Module>
-  <Module CommonName="Upper Shadowlands" WarpCode="kas_m24aa">
-    <LeadsTo CommonName="Great Walkway" WarpCode="kas_m22ab" />
-    <LeadsTo CommonName="Lower Shadowlands" WarpCode="kas_m25aa" />
-    <LeadsTo CommonName="Chieftain's Hall" WarpCode="kas_m23ad" />
+  <Module WarpCode="unk_m41ab" CommonName="South Beach">
+    <LeadsTo WarpCode="unk_m42aa" CommonName="Elder Settlement" />
+    <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
   </Module>
-  <Module CommonName="Lower Shadowlands" WarpCode="kas_m25aa">
-    <LeadsTo CommonName="Upper Shadowlands" WarpCode="kas_m24aa" />
+  <Module WarpCode="unk_m41ac" CommonName="North Beach">
+    <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
+    <LeadsTo WarpCode="unk_m43aa" CommonName="Rakatan Settlement" />
   </Module>
-  <Module CommonName="Dreshdae" WarpCode="korr_m33aa">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-    <LeadsTo CommonName="Sith Academy" WarpCode="korr_m35aa" />
-    <LeadsTo CommonName="Sith Academy Entrance" WarpCode="korr_m33ab" />
+  <Module WarpCode="unk_m41ad" CommonName="Temple Exterior">
+    <LeadsTo WarpCode="unk_m41aa" CommonName="Central Beach" />
+    <LeadsTo WarpCode="unk_m41ab" CommonName="South Beach" />
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,GPTP,DLZ" />
   </Module>
-  <Module CommonName="Sith Academy Entrance" WarpCode="korr_m33ab">
-    <LeadsTo CommonName="Dreshdae" WarpCode="korr_m33aa" />
-    <LeadsTo CommonName="Sith Academy" WarpCode="korr_m35aa" />
+  <Module WarpCode="unk_m42aa" CommonName="Elder Settlement">
+    <LeadsTo WarpCode="unk_m41ab" CommonName="South Beach" />
   </Module>
-  <Module CommonName="Shyrack Caves" WarpCode="korr_m34aa">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
+  <Module WarpCode="unk_m43aa" CommonName="Rakatan Settlement">
+    <LeadsTo WarpCode="unk_m41ac" CommonName="North Beach" />
   </Module>
-  <Module CommonName="Sith Academy" WarpCode="korr_m35aa">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
-    <LeadsTo CommonName="Sith Academy Entrance" WarpCode="korr_m33ab" />
-    <LeadsTo CommonName="Tomb of Naga Sadow" WarpCode="korr_m39aa" />
+  <Module WarpCode="unk_m44aa" CommonName="Temple Main Floor">
+    <LeadsTo WarpCode="unk_m41ad" CommonName="Temple Exterior" />
+    <LeadsTo WarpCode="unk_m44ab" CommonName="Temple Catacombs" />
+    <LeadsTo WarpCode="unk_m44ac" CommonName="Temple Summit" Tags="Locked,GPTP,DLZ" />
   </Module>
-  <Module CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa">
-    <LeadsTo CommonName="Shyrack Caves" WarpCode="korr_m34aa" />
-    <LeadsTo CommonName="Sith Academy" WarpCode="korr_m35aa" />
-    <LeadsTo CommonName="Tomb of Naga Sadow" WarpCode="korr_m39aa" />
-    <LeadsTo CommonName="Tomb of Ajunta Pall" WarpCode="korr_m37aa" />
-    <LeadsTo CommonName="Tomb of Marka Ragnos" WarpCode="korr_m38aa" />
-    <LeadsTo CommonName="Tomb of Tulak Hord" WarpCode="korr_m38ab" />
+  <Module WarpCode="unk_m44ab" CommonName="Temple Catacombs">
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
   </Module>
-  <Module CommonName="Tomb of Ajunta Pall" WarpCode="korr_m37aa">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
-  </Module>
-  <Module CommonName="Tomb of Marka Ragnos" WarpCode="korr_m38aa">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
-  </Module>
-  <Module CommonName="Tomb of Tulak Hord" WarpCode="korr_m38ab">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
-  </Module>
-  <Module CommonName="Tomb of Naga Sadow" WarpCode="korr_m39aa">
-    <LeadsTo CommonName="Valley of the Dark Lords" WarpCode="korr_m36aa" />
+  <Module WarpCode="unk_m44ac" CommonName="Temple Summit">
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
   </Module>
-  <Module CommonName="Prison Block" WarpCode="lev_m40aa">
-    <LeadsTo CommonName="Command Deck" WarpCode="lev_m40ab" />
-    <LeadsTo CommonName="Leviathan Hangar" WarpCode="lev_m40ac" />
+  
+  <!--Cutscene Modules-->
+  <Module WarpCode="ebo_m40aa" CommonName="Leviathan Game-Plan Cutscene">
   </Module>
-  <Module CommonName="Command Deck" WarpCode="lev_m40ab">
-    <LeadsTo CommonName="Prison Block" WarpCode="lev_m40aa" />
-    <LeadsTo CommonName="Leviathan Hangar" WarpCode="lev_m40ac" />
-    <LeadsTo CommonName="Leviathan Bridge" WarpCode="lev_m40ad" />
-  </Module>
-  <Module CommonName="Leviathan Hangar" WarpCode="lev_m40ac">
-    <LeadsTo CommonName="Prison Block" WarpCode="lev_m40aa" />
-    <LeadsTo CommonName="Command Deck" WarpCode="lev_m40ab" />
-  </Module>
-  <Module CommonName="Leviathan Bridge" WarpCode="lev_m40ad">
-    <LeadsTo CommonName="Command Deck" WarpCode="lev_m40ab" />
-  </Module>
-  <Module CommonName="Yavin Station" WarpCode="liv_m99aa">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-  </Module>
-  <Module CommonName="Ahto West" WarpCode="manm26aa">
-    <LeadsTo CommonName="West Central" WarpCode="manm26ac" />
-  </Module>
-  <Module CommonName="Ahto East" WarpCode="manm26ab">
-    <LeadsTo CommonName="East Central" WarpCode="manm26ae" />
-    <LeadsTo CommonName="Manaan Sith Base" WarpCode="manm27aa" />
-    <LeadsTo CommonName="Manaan Swoops" WarpCode="manm26mg" />
-    <LeadsTo CommonName="Ahto West" WarpCode="manm26aa" />
-  </Module>
-  <Module CommonName="West Central" WarpCode="manm26ac">
-    <LeadsTo CommonName="East Central" WarpCode="manm26ae" />
-    <LeadsTo CommonName="Ahto West" WarpCode="manm26aa" />
-    <LeadsTo CommonName="Manaan Docking Bay" WarpCode="manm26ad" />
-  </Module>
-  <Module CommonName="Manaan Docking Bay" WarpCode="manm26ad">
-    <LeadsTo CommonName="West Central" WarpCode="manm26ac" />
-    <LeadsTo CommonName="Manaan Sith Base" WarpCode="manm27aa" />
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-  </Module>
-  <Module CommonName="East Central" WarpCode="manm26ae">
-    <LeadsTo CommonName="West Central" WarpCode="manm26ac" />
-    <LeadsTo CommonName="Ahto East" WarpCode="manm26ab" />
-    <LeadsTo CommonName="Hrakert Station" WarpCode="manm28aa" />
-  </Module>
-  <Module CommonName="Manaan Swoops" WarpCode="manm26mg">
-    <LeadsTo CommonName="Ahto East" WarpCode="manm26ab" />
-  </Module>
-  <Module CommonName="Manaan Sith Base" WarpCode="manm27aa">
-    <LeadsTo CommonName="Ahto East" WarpCode="manm26ab" />
-  </Module>
-  <Module CommonName="Hrakert Station" WarpCode="manm28aa">
-    <LeadsTo CommonName="Sea Floor" WarpCode="manm28ab" />
-    <LeadsTo CommonName="Hrakert Rift" WarpCode="manm28ad" />
-    <LeadsTo CommonName="East Central" WarpCode="manm26ae" />
+  <Module WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan">
   </Module>
-  <Module CommonName="Sea Floor" WarpCode="manm28ab">
-    <LeadsTo CommonName="Hrakert Station" WarpCode="manm28aa" />
-    <LeadsTo CommonName="Kolto Control" WarpCode="manm28ac" />
-  </Module>
-  <Module CommonName="Kolto Control" WarpCode="manm28ac">
-    <LeadsTo CommonName="Sea Floor" WarpCode="manm28ab" />
-    <LeadsTo CommonName="Hrakert Rift" WarpCode="manm28ad" />
-  </Module>
-  <Module CommonName="Hrakert Rift" WarpCode="manm28ad">
-    <LeadsTo CommonName="Hrakert Station" WarpCode="manm28aa" />
-    <LeadsTo CommonName="Kolto Control" WarpCode="manm28ac" />
-  </Module>
-  <Module CommonName="Deck 1" WarpCode="sta_m45aa">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-    <LeadsTo CommonName="Deck 2" WarpCode="sta_m45ab" />
-  </Module>
-  <Module CommonName="Deck 2" WarpCode="sta_m45ab">
-    <LeadsTo CommonName="Deck 1" WarpCode="sta_m45aa" />
-    <LeadsTo CommonName="Deck 3" WarpCode="sta_m45ac" />
+  <Module WarpCode="M12ab"     CommonName="Fighter Skirmish">
   </Module>
-  <Module CommonName="Deck 3" WarpCode="sta_m45ac">
-    <LeadsTo CommonName="Deck 2" WarpCode="sta_m45ab" />
-    <LeadsTo CommonName="Deck 4" WarpCode="sta_m45ad" />
-  </Module>
-  <Module CommonName="Deck 4" WarpCode="sta_m45ad">
-    <LeadsTo CommonName="Deck 3" WarpCode="sta_m45ac" />
-  </Module>
-  <Module CommonName="South Apartments" WarpCode="tar_m02aa">
-    <LeadsTo CommonName="Hideout" WarpCode="tar_m02af" />
-    <LeadsTo CommonName="Upper City South" WarpCode="tar_m02ac" />
-  </Module>
-  <Module CommonName="Upper City North" WarpCode="tar_m02ab">
-    <LeadsTo CommonName="North Apartments" WarpCode="tar_m02ad" />
-    <LeadsTo CommonName="Upper City South" WarpCode="tar_m02ac" />
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Taris Sith Base" WarpCode="tar_m09aa" />
-  </Module>
-  <Module CommonName="Upper City South" WarpCode="tar_m02ac">
-    <LeadsTo CommonName="South Apartments" WarpCode="tar_m02aa" />
-    <LeadsTo CommonName="Upper City North" WarpCode="tar_m02ab" />
-    <LeadsTo CommonName="Upper City Cantina" WarpCode="tar_m02ae" />
-  </Module>
-  <Module CommonName="North Apartments" WarpCode="tar_m02ad">
-    <LeadsTo CommonName="Upper City North" WarpCode="tar_m02ab" />
-  </Module>
-  <Module CommonName="Upper City Cantina" WarpCode="tar_m02ae">
-    <LeadsTo CommonName="Upper City South" WarpCode="tar_m02ac" />
-  </Module>
-  <Module CommonName="Hideout" WarpCode="tar_m02af">
-    <LeadsTo CommonName="South Apartments" WarpCode="tar_m02aa" />
-  </Module>
-  <Module CommonName="Lower City" WarpCode="tar_m03aa">
-    <LeadsTo CommonName="Upper City North" WarpCode="tar_m02ab" />
-    <LeadsTo CommonName="Lower City Apt West" WarpCode="tar_m03ab" />
-    <LeadsTo CommonName="Lower City Apt East" WarpCode="tar_m03ad" />
-    <LeadsTo CommonName="Vulkar Base" WarpCode="tar_m10aa" />
-    <LeadsTo CommonName="Bek Base" WarpCode="tar_m11aa" />
-    <LeadsTo CommonName="Javyar's Cantina" WarpCode="tar_m03ae" />
-    <LeadsTo CommonName="Undercity" WarpCode="tar_m04aa" />
-  </Module>
-  <Module CommonName="Lower City Apt West" WarpCode="tar_m03ab">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-  </Module>
-  <Module CommonName="Lower City Apt East" WarpCode="tar_m03ad">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
+  <Module WarpCode="STUNT_00"  CommonName="Dream Sequence">
   </Module>
-  <Module CommonName="Javyar's Cantina" WarpCode="tar_m03ae">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Davik's Estate" WarpCode="tar_m08aa" />
+  <Module WarpCode="STUNT_03a" CommonName="Malak Orders Taris Destroyed">
+    <!--Davik's Estate--> <!--works multiple times-->
   </Module>
-  <Module CommonName="Swoop Platform" WarpCode="tar_m03af">
-    <LeadsTo CommonName="Taris Swoops" WarpCode="tar_m03mg" />
-    <LeadsTo CommonName="Hideout" WarpCode="tar_m02af" />
+  <Module WarpCode="STUNT_06"  CommonName="Taris Destruction Update">
+    <!--Escaping Taris on the Ebon Hawk-->
   </Module>
-  <Module CommonName="Taris Swoops" WarpCode="tar_m03mg">
-    <LeadsTo CommonName="Swoop Platform" WarpCode="tar_m03af" />
-  </Module>
-  <Module CommonName="Undercity" WarpCode="tar_m04aa">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Lower Sewers" WarpCode="tar_m05aa" />
-  </Module>
-  <Module CommonName="Lower Sewers" WarpCode="tar_m05aa">
-    <LeadsTo CommonName="Undercity" WarpCode="tar_m04aa" />
-    <LeadsTo CommonName="Upper Sewers" WarpCode="tar_m05ab" />
-  </Module>
-  <Module CommonName="Upper Sewers" WarpCode="tar_m05ab">
-    <LeadsTo CommonName="Lower Sewers" WarpCode="tar_m05aa" />
-    <LeadsTo CommonName="Vulkar Base" WarpCode="tar_m10aa" />
-  </Module>
-  <Module CommonName="Davik's Estate" WarpCode="tar_m08aa">
-    <LeadsTo CommonName="Jedi Enclave" WarpCode="danm13" />
-  </Module>
-  <Module CommonName="Taris Sith Base" WarpCode="tar_m09aa">
-    <LeadsTo CommonName="Governor Office" WarpCode="tar_m09ab" />
-    <LeadsTo CommonName="Upper City North" WarpCode="tar_m02ab" />
-  </Module>
-  <Module CommonName="Governor Office" WarpCode="tar_m09ab">
-    <LeadsTo CommonName="Taris Sith Base" WarpCode="tar_m09aa" />
-  </Module>
-  <Module CommonName="Vulkar Base" WarpCode="tar_m10aa">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Upper Sewers" WarpCode="tar_m05ab" />
-    <LeadsTo CommonName="Vulkar Garage" WarpCode="tar_m10ac" />
-    <LeadsTo CommonName="Swoop Platform" WarpCode="tar_m03af" />
+  <Module WarpCode="STUNT_07"  CommonName="Escaping Taris on the Ebon Hawk">
+    <!--Fighter Skirmish-->
   </Module>
-  <Module CommonName="Vulkar Spice Lab" WarpCode="tar_m10ab">
-    <LeadsTo CommonName="Vulkar Base" WarpCode="tar_m10aa" />
-  </Module>
-  <Module CommonName="Vulkar Garage" WarpCode="tar_m10ac">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Vulkar Base" WarpCode="tar_m10aa" />
-  </Module>
-  <Module CommonName="Bek Base" WarpCode="tar_m11aa">
-    <LeadsTo CommonName="Lower City" WarpCode="tar_m03aa" />
-    <LeadsTo CommonName="Gadon's Office" WarpCode="tar_m11ab" />
-  </Module>
-  <Module CommonName="Gadon's Office" WarpCode="tar_m11ab">
-    <LeadsTo CommonName="Bek Base" WarpCode="tar_m11aa" />
-  </Module>
-  <Module CommonName="Anchorhead" WarpCode="tat_m17aa">
-    <LeadsTo CommonName="Tatooine Docking Bay" WarpCode="tat_m17ab" />
-    <LeadsTo CommonName="Hunting Lodge" WarpCode="tat_m17ad" />
-    <LeadsTo CommonName="Czerka Office" WarpCode="tat_m17ag" />
-    <LeadsTo CommonName="Swoop Registration" WarpCode="tat_m17ae" />
-    <LeadsTo CommonName="Tatooine Cantina" WarpCode="tat_m17af" />
-    <LeadsTo CommonName="Droid Shop" WarpCode="tat_m17ac" />
-    <LeadsTo CommonName="Dune Sea" WarpCode="tat_m18aa" />
-  </Module>
-  <Module CommonName="Tatooine Docking Bay" WarpCode="tat_m17ab">
-    <LeadsTo CommonName="Ebon Hawk" WarpCode="ebo_m12aa" />
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-  </Module>
-  <Module CommonName="Droid Shop" WarpCode="tat_m17ac">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-  </Module>
-  <Module CommonName="Hunting Lodge" WarpCode="tat_m17ad">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-  </Module>
-  <Module CommonName="Swoop Registration" WarpCode="tat_m17ae">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-    <LeadsTo CommonName="Tatooine Swoops" WarpCode="tat_m17mg" />
-  </Module>
-  <Module CommonName="Tatooine Cantina" WarpCode="tat_m17af">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-  </Module>
-  <Module CommonName="Czerka Office" WarpCode="tat_m17ag">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-  </Module>
-  <Module CommonName="Tatooine Swoops" WarpCode="tat_m17mg">
-    <LeadsTo CommonName="Swoop Registration" WarpCode="tat_m17ae" />
-  </Module>
-  <Module CommonName="Dune Sea" WarpCode="tat_m18aa">
-    <LeadsTo CommonName="Anchorhead" WarpCode="tat_m17aa" />
-    <LeadsTo CommonName="Eastern Dune Sea" WarpCode="tat_m18ac" />
-    <LeadsTo CommonName="Sand People Territory" WarpCode="tat_m18ab" />
-  </Module>
-  <Module CommonName="Sand People Territory" WarpCode="tat_m18ab">
-    <LeadsTo CommonName="Dune Sea" WarpCode="tat_m18aa" />
-    <LeadsTo CommonName="Eastern Dune Sea" WarpCode="tat_m18ac" />
-    <LeadsTo CommonName="Sand People Enclave" WarpCode="tat_m20aa" />
-  </Module>
-  <Module CommonName="Eastern Dune Sea" WarpCode="tat_m18ac">
-    <LeadsTo CommonName="Dune Sea" WarpCode="tat_m18aa" />
-    <LeadsTo CommonName="Sand People Territory" WarpCode="tat_m18ab" />
-  </Module>
-  <Module CommonName="Sand People Enclave" WarpCode="tat_m20aa">
-    <LeadsTo CommonName="Sand People Territory" WarpCode="tat_m18ab" />
-  </Module>
-  <Module CommonName="Central Beach" WarpCode="unk_m41aa">
-    <LeadsTo CommonName="Lehon Hawk" WarpCode="ebo_m41aa" />
-    <LeadsTo CommonName="North Beach" WarpCode="unk_m41ac" />
-    <LeadsTo CommonName="Temple Exterior" WarpCode="unk_m41ad" />
-  </Module>
-  <Module CommonName="South Beach" WarpCode="unk_m41ab">
-    <LeadsTo CommonName="Elder Settlement" WarpCode="unk_m42aa" />
-    <LeadsTo CommonName="Temple Exterior" WarpCode="unk_m41ad" />
-  </Module>
-  <Module CommonName="North Beach" WarpCode="unk_m41ac">
-    <LeadsTo CommonName="Central Beach" WarpCode="unk_m41aa" />
-    <LeadsTo CommonName="Rakatan Settlement" WarpCode="unk_m43aa" />
-  </Module>
-  <Module CommonName="Temple Exterior" WarpCode="unk_m41ad">
-    <LeadsTo CommonName="Central Beach" WarpCode="unk_m41aa" />
-    <LeadsTo CommonName="South Beach" WarpCode="unk_m41ab" />
-    <LeadsTo CommonName="Temple Main Floor" WarpCode="unk_m44aa" />
-  </Module>
-  <Module CommonName="Elder Settlement" WarpCode="unk_m42aa">
-    <LeadsTo CommonName="South Beach" WarpCode="unk_m41ab" />
-  </Module>
-  <Module CommonName="Rakatan Settlement" WarpCode="unk_m43aa">
-    <LeadsTo CommonName="North Beach" WarpCode="unk_m41ac" />
-  </Module>
-  <Module CommonName="Temple Main Floor" WarpCode="unk_m44aa">
-    <LeadsTo CommonName="Temple Exterior" WarpCode="unk_m41ad" />
-    <LeadsTo CommonName="Temple Catacombs" WarpCode="unk_m44ab" />
-    <LeadsTo CommonName="Temple Summit" WarpCode="unk_m44ac" />
-  </Module>
-  <Module CommonName="Temple Catacombs" WarpCode="unk_m44ab">
-    <LeadsTo CommonName="Temple Main Floor" WarpCode="unk_m44aa" />
-  </Module>
-  <Module CommonName="Temple Summit" WarpCode="unk_m44ac">
-    <LeadsTo CommonName="Temple Main Floor" WarpCode="unk_m44aa" />
-  </Module>
-  <Module WarpCode="ebo_m40aa" CommonName="Leviathan Game-Plan Cutscene" />
-  <Module WarpCode="ebo_m40ad" CommonName="Escaped The Leviathan" />
-  <Module WarpCode="M12ab"     CommonName="Fighter Skirmish" />
-  <Module WarpCode="STUNT_00"  CommonName="Dream Sequence" />
-  <Module WarpCode="STUNT_03a" CommonName="Malak Orders Taris Destroyed" />
-  <Module WarpCode="STUNT_06"  CommonName="Taris Destruction Update" />
-  <Module WarpCode="STUNT_07"  CommonName="Escaping Taris on the Ebon Hawk" />
-  <Module WarpCode="STUNT_12"  CommonName="Calo Nord is Alive" />
-  <Module WarpCode="STUNT_14"  CommonName="Darth Bandon Recruited" />
-  <Module WarpCode="STUNT_16"  CommonName="Leviathan Captured (Old Mentor)" />
-  <Module WarpCode="STUNT_18"  CommonName="Bastila is Tortured" />
-  <Module WarpCode="STUNT_19"  CommonName="Jaw Drop" />
-  <Module WarpCode="STUNT_31b" CommonName="Revan Reveal" />
-  <Module WarpCode="STUNT_34"  CommonName="Star Forge Arrival" />
-  <Module WarpCode="STUNT_35"  CommonName="Lehon Distruptor Field" />
-  <Module WarpCode="STUNT_42"  CommonName="Pre-Star Forge Cutscene (Light Side)" />
-  <Module WarpCode="STUNT_44"  CommonName="Pre-Star Forge Cutscene (Dark Side)" />
-  <Module WarpCode="STUNT_50a" CommonName="Green Squadron" />
-  <Module WarpCode="STUNT_51a" CommonName="Bastila Destroys the Republic Fleet" />
-  <Module WarpCode="STUNT_54a" CommonName="The Republic is Doomed" />
-  <Module WarpCode="STUNT_55a" CommonName="All Hail Lord Revan (Dark Credits)" />
-  <Module WarpCode="STUNT_56a" CommonName="Star Forge Destroyed" />
-  <Module WarpCode="STUNT_57"  CommonName="The Sith are Defeated (Light Credits)" />
+  <Module WarpCode="STUNT_12"  CommonName="Calo Nord is Alive">
+    <!--Ebon Hawk (ebo_m12aa)-->
+  </Module>
+  <Module WarpCode="STUNT_14"  CommonName="Darth Bandon Recruited">
+    <!--Ebon Hawk (ebo_m12aa)-->
+  </Module>
+  <Module WarpCode="STUNT_16"  CommonName="Leviathan Captured (Old Mentor)">
+    <!--Leviathan Game-Plan Cutscene (ebo_m40aa)-->
+  </Module>
+  <Module WarpCode="STUNT_18"  CommonName="Bastila is Tortured">
+    <!--STUNT_34-->
+  </Module>
+  <Module WarpCode="STUNT_19"  CommonName="Jaw Drop">
+    <!--Temple Main Floor (unk_m44aa)-->
+  </Module>
+  <Module WarpCode="STUNT_31b" CommonName="Revan Reveal">
+    <!--Leviathan Hangar (lev_m40ac)-->
+  </Module>
+  <Module WarpCode="STUNT_34"  CommonName="Star Forge Arrival">
+    <!--Fighter Encounter-->
+  </Module>
+  <Module WarpCode="STUNT_35"  CommonName="Lehon Distruptor Field">
+    <!--Lehon Hawk (ebo_m41aa)-->
+  </Module>
+  <Module WarpCode="STUNT_42"  CommonName="Pre-Star Forge Cutscene (Light Side)">
+    <!--Ebon Hawk-->
+  </Module>
+  <Module WarpCode="STUNT_44"  CommonName="Pre-Star Forge Cutscene (Dark Side)">
+    <!--Ebon Hawk-->
+  </Module>
+  <Module WarpCode="STUNT_50a" CommonName="Green Squadron">
+    <!--SF - Command Center ()-->
+  </Module>
+  <Module WarpCode="STUNT_51a" CommonName="Bastila Destroys the Republic Fleet">
+    <!--SF - Command Center ()-->
+  </Module>
+  <Module WarpCode="STUNT_54a" CommonName="The Republic is Doomed">
+    <!--All Hail Lord Revan (STUNT_55a)-->
+  </Module>
+  <Module WarpCode="STUNT_55a" CommonName="All Hail Lord Revan (Dark Credits)">
+    <!--End of game - Main Menu-->
+  </Module>
+  <Module WarpCode="STUNT_56a" CommonName="Star Forge Destroyed">
+    <!--The Sith are Defeated (STUNT_57)-->
+  </Module>
+  <Module WarpCode="STUNT_57"  CommonName="The Sith are Defeated (Light Credits)">
+    <!--End of game - Main Menu-->
+  </Module>
 </Modules>

--- a/kotor Randomizer 2/kotor Randomizer 2.csproj
+++ b/kotor Randomizer 2/kotor Randomizer 2.csproj
@@ -84,6 +84,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Digraph.cs" />
     <Compile Include="Forms\TwodaForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -266,7 +267,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Xml\KotorModules.xml" />
+    <Content Include="Xml\KotorModules.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Notes\KRPformat.txt" />
     <None Include="Resources\help\GeneralHelp.txt" />
     <None Include="Resources\help\ModuleHelp.txt" />


### PR DESCRIPTION
#3 Implements goal-based reachability verification using an XML file to describe all game modules and transitions between modules.

Three goals are currently available for use: Malak, Star Maps, and Pazaak. These are represented as tags on the module elements in the XML file. For a goal to be achievable, all modules with the associated tag must be reachable. New goals will be easy to add in the future.

Before module randomization, a digraph representing the entire game is created from the module information. The module shuffle is generated as usual, but before it is used to copy module files, the random shuffle is passed to the digraph to verify if the currently selected goals are reachable. If the goal is not achievable, another shuffle is generated and verified. This continues until a reachable solution is found or until 10,000 attempts have been made. This might be an excessively high number, but time will tell if another end condition would be better suited.

Reachability, and all associated settings, can be enabled or disabled at the bottom of the Modules form. Single-use transitions can be explicitly ignored to improve the user's experience.

In addition to this, popup tool tips have been added for the checkboxes on the Modules form. More of these will be added in the future for other forms to improve the user's understanding of the available settings.