### PR TITLE
Implemented swoop race randomization.

### DIFF
--- a/Patch Sources/Patch Sources.csproj
+++ b/Patch Sources/Patch Sources.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A0BF410A-69C7-4ED2-BBCE-395047D3A8DD}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Patch_Sources</RootNamespace>
     <AssemblyName>Patch Sources</AssemblyName>
@@ -31,6 +31,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <None Include="k_pebn_galaxy.nss" />

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Kotor Randomizer was created by Lane and Glasnonck, with help from the kotor
 * Cause torso equipment to randomly polymorph the character equipping it.
 * Randomize the cards found in NPC pazaak decks.
 * Randomize which NPCs and Creatures are your party members.
+* Alter swoop races by randomizing the placement of booster pads and/or obstacles.
 ---
 **Presets and Seeding**
 * Save your wild randomizer settings to a file that can be pulled up later

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -250,6 +250,12 @@
             <setting name="IgnoreOnceEdges" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="RandomizeSwoopBoosters" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="RandomizeSwoopObstacles" serializeAs="String">
+                <value>False</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/Forms/OtherForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/OtherForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.label1 = new System.Windows.Forms.Label();
             this.tbNameData = new System.Windows.Forms.TextBox();
             this.cbNameList = new System.Windows.Forms.ComboBox();
@@ -35,6 +36,10 @@
             this.cbNameGen = new System.Windows.Forms.CheckBox();
             this.cbPazaak = new System.Windows.Forms.CheckBox();
             this.cbPartyRando = new System.Windows.Forms.CheckBox();
+            this.cbSwoopBoosters = new System.Windows.Forms.CheckBox();
+            this.lblSwoopRando = new System.Windows.Forms.Label();
+            this.cbSwoopObstacles = new System.Windows.Forms.CheckBox();
+            this.OtherToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // label1
@@ -78,15 +83,16 @@
             // 
             // cbPolymorph
             // 
+            this.cbPolymorph.AutoSize = true;
             this.cbPolymorph.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.cbPolymorph.Location = new System.Drawing.Point(180, 20);
+            this.cbPolymorph.Location = new System.Drawing.Point(189, 20);
             this.cbPolymorph.Name = "cbPolymorph";
-            this.cbPolymorph.Size = new System.Drawing.Size(120, 140);
+            this.cbPolymorph.Size = new System.Drawing.Size(158, 17);
             this.cbPolymorph.TabIndex = 51;
-            this.cbPolymorph.Text = "Polymorph Mode - Causes equipable items to have random disguise modifiers, essent" +
-    "ially allowing the player to polymorph. (Doesn\'t synergize well with model rando" +
-    ")";
+            this.cbPolymorph.Text = "Equipment Polymorph Mode";
             this.cbPolymorph.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.OtherToolTip.SetToolTip(this.cbPolymorph, "Causes equipable items to have random disguise modifiers,\r\nessentially allowing t" +
+        "he player to polymorph.\r\n(Doesn\'t synergize well with model rando!)");
             this.cbPolymorph.UseVisualStyleBackColor = true;
             this.cbPolymorph.CheckedChanged += new System.EventHandler(this.cbPolymorph_CheckedChanged);
             // 
@@ -103,36 +109,79 @@
             // 
             // cbPazaak
             // 
+            this.cbPazaak.AutoSize = true;
             this.cbPazaak.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.cbPazaak.Location = new System.Drawing.Point(180, 170);
+            this.cbPazaak.Location = new System.Drawing.Point(189, 43);
             this.cbPazaak.Name = "cbPazaak";
-            this.cbPazaak.Size = new System.Drawing.Size(120, 90);
+            this.cbPazaak.Size = new System.Drawing.Size(177, 17);
             this.cbPazaak.TabIndex = 53;
-            this.cbPazaak.Text = "Random Pazaak Decks - Randomizes the cards contained within the NPC pazaak decks." +
-    "";
+            this.cbPazaak.Text = "Randomize NPC Pazaak Decks";
             this.cbPazaak.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.OtherToolTip.SetToolTip(this.cbPazaak, "Randomizes the cards contained within the NPC pazaak decks.");
             this.cbPazaak.UseVisualStyleBackColor = true;
             this.cbPazaak.CheckedChanged += new System.EventHandler(this.cbPazaak_CheckedChanged);
             // 
             // cbPartyRando
             // 
+            this.cbPartyRando.AutoSize = true;
             this.cbPartyRando.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.cbPartyRando.Location = new System.Drawing.Point(180, 270);
+            this.cbPartyRando.Location = new System.Drawing.Point(189, 66);
             this.cbPartyRando.Name = "cbPartyRando";
-            this.cbPartyRando.Size = new System.Drawing.Size(120, 110);
+            this.cbPartyRando.Size = new System.Drawing.Size(152, 17);
             this.cbPartyRando.TabIndex = 54;
-            this.cbPartyRando.Text = "Randomize Party Members - This entirely morphs each party member into a different" +
-    " creature, wth different stats and equipment.\r\n";
+            this.cbPartyRando.Text = "Randomize Party Members";
             this.cbPartyRando.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.OtherToolTip.SetToolTip(this.cbPartyRando, "This entirely morphs each party member into a different creature,\r\nwth different " +
+        "stats and equipment.");
             this.cbPartyRando.UseVisualStyleBackColor = true;
             this.cbPartyRando.CheckedChanged += new System.EventHandler(this.cbPartyRando_CheckedChanged);
+            // 
+            // cbSwoopBoosters
+            // 
+            this.cbSwoopBoosters.AutoSize = true;
+            this.cbSwoopBoosters.Location = new System.Drawing.Point(209, 109);
+            this.cbSwoopBoosters.Name = "cbSwoopBoosters";
+            this.cbSwoopBoosters.Size = new System.Drawing.Size(89, 17);
+            this.cbSwoopBoosters.TabIndex = 55;
+            this.cbSwoopBoosters.Text = "Booster Pads";
+            this.OtherToolTip.SetToolTip(this.cbSwoopBoosters, "Randomizes the placement of booster pads in each swoop\r\ntrack - Taris, Tatooine, " +
+        "and Manaan.");
+            this.cbSwoopBoosters.UseVisualStyleBackColor = true;
+            this.cbSwoopBoosters.CheckedChanged += new System.EventHandler(this.cbSwoopBoosters_CheckedChanged);
+            // 
+            // lblSwoopRando
+            // 
+            this.lblSwoopRando.AutoSize = true;
+            this.lblSwoopRando.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblSwoopRando.Location = new System.Drawing.Point(186, 90);
+            this.lblSwoopRando.Name = "lblSwoopRando";
+            this.lblSwoopRando.Size = new System.Drawing.Size(142, 13);
+            this.lblSwoopRando.TabIndex = 56;
+            this.lblSwoopRando.Text = "Swoop Race Randomization";
+            // 
+            // cbSwoopObstacles
+            // 
+            this.cbSwoopObstacles.AutoSize = true;
+            this.cbSwoopObstacles.Location = new System.Drawing.Point(209, 132);
+            this.cbSwoopObstacles.Name = "cbSwoopObstacles";
+            this.cbSwoopObstacles.Size = new System.Drawing.Size(73, 17);
+            this.cbSwoopObstacles.TabIndex = 57;
+            this.cbSwoopObstacles.Text = "Obstacles";
+            this.OtherToolTip.SetToolTip(this.cbSwoopObstacles, "**NOT RECOMMENDED**\r\nRandomizes the placement of obstacles in each swoop\r\ntrack -" +
+        " Taris, Tatooine, and Manaan.\r\n** Visual location of the obstacles does not chan" +
+        "ge!");
+            this.cbSwoopObstacles.UseVisualStyleBackColor = true;
+            this.cbSwoopObstacles.CheckedChanged += new System.EventHandler(this.cbSwoopObstacles_CheckedChanged);
             // 
             // OtherForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(365, 401);
+            this.ClientSize = new System.Drawing.Size(374, 401);
+            this.Controls.Add(this.cbSwoopObstacles);
+            this.Controls.Add(this.lblSwoopRando);
+            this.Controls.Add(this.cbSwoopBoosters);
             this.Controls.Add(this.cbPartyRando);
             this.Controls.Add(this.cbPazaak);
             this.Controls.Add(this.cbNameGen);
@@ -161,5 +210,9 @@
         private System.Windows.Forms.CheckBox cbNameGen;
         private System.Windows.Forms.CheckBox cbPazaak;
         private System.Windows.Forms.CheckBox cbPartyRando;
+        private System.Windows.Forms.CheckBox cbSwoopBoosters;
+        private System.Windows.Forms.Label lblSwoopRando;
+        private System.Windows.Forms.CheckBox cbSwoopObstacles;
+        private System.Windows.Forms.ToolTip OtherToolTip;
     }
 }

--- a/kotor Randomizer 2/Forms/OtherForm.cs
+++ b/kotor Randomizer 2/Forms/OtherForm.cs
@@ -23,6 +23,8 @@ namespace kotor_Randomizer_2
             cbPolymorph.Checked = Properties.Settings.Default.PolymorphMode;
             cbPazaak.Checked = Properties.Settings.Default.RandomizePazaakDecks;
             cbPartyRando.Checked = Properties.Settings.Default.RandomizePartyMembers;
+            cbSwoopBoosters.Checked = Properties.Settings.Default.RandomizeSwoopBoosters;
+            cbSwoopObstacles.Checked = Properties.Settings.Default.RandomizeSwoopObstacles;
         }
 
         #region private properties
@@ -134,6 +136,16 @@ namespace kotor_Randomizer_2
         private void cbPartyRando_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.RandomizePartyMembers = cbPartyRando.Checked;
+        }
+
+        private void cbSwoopBoosters_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.RandomizeSwoopBoosters = cbSwoopBoosters.Checked;
+        }
+
+        private void cbSwoopObstacles_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.RandomizeSwoopObstacles = cbSwoopObstacles.Checked;
         }
 
         #endregion

--- a/kotor Randomizer 2/Forms/OtherForm.resx
+++ b/kotor Randomizer 2/Forms/OtherForm.resx
@@ -117,4 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="OtherToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="OtherToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>67</value>
+  </metadata>
 </root>

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -299,6 +299,9 @@ namespace kotor_Randomizer_2
 
                         Properties.Settings.Default.PolymorphMode = br.ReadBoolean();
                         Properties.Settings.Default.RandomizePazaakDecks = br.ReadBoolean();
+                        Properties.Settings.Default.RandomizePartyMembers = br.ReadBoolean();
+                        Properties.Settings.Default.RandomizeSwoopBoosters = br.ReadBoolean();
+                        Properties.Settings.Default.RandomizeSwoopObstacles = br.ReadBoolean();
                     }
                     #endregion
 
@@ -326,7 +329,7 @@ namespace kotor_Randomizer_2
                 bw.Write(Properties.Settings.Default.DoRandomization_Other);
 
                 // Categories
-                // Modules
+                #region Modules
                 if (Properties.Settings.Default.DoRandomization_Module)
                 {
                     bw.Write("MODU".ToCharArray());
@@ -351,7 +354,8 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ));    // Add Vulkar Spice Loading Zone
 
                 }
-                // Items
+                #endregion
+                #region Items
                 if (Properties.Settings.Default.DoRandomization_Item)
                 {
                     bw.Write("ITEM".ToCharArray());
@@ -382,7 +386,8 @@ namespace kotor_Randomizer_2
                     }
                     bw.Write('\n');
                 }
-                // Sounds
+                #endregion
+                #region Sounds
                 if (Properties.Settings.Default.DoRandomization_Sound)
                 {
                     bw.Write("SOUN".ToCharArray());
@@ -397,7 +402,8 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.MixNpcAndPartySounds);
 
                 }
-                // Models
+                #endregion
+                #region Models
                 if (Properties.Settings.Default.DoRandomization_Model)
                 {
                     bw.Write("MODE".ToCharArray());
@@ -406,7 +412,8 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.RandomizePlaceModels);
                     bw.Write(Properties.Settings.Default.RandomizeDoorModels);
                 }
-                // Textures
+                #endregion
+                #region Textures
                 if (Properties.Settings.Default.DoRandomization_Texture)
                 {
                     bw.Write("TEXU".ToCharArray());
@@ -429,7 +436,8 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.TexturePack);
 
                 }
-                // 2DAs
+                #endregion
+                #region 2DAs
                 if (Properties.Settings.Default.DoRandomization_TwoDA)
                 {
                     bw.Write("TWDA".ToCharArray());
@@ -449,7 +457,8 @@ namespace kotor_Randomizer_2
                     bw.Write('\x3');
 
                 }
-                // Text
+                #endregion
+                #region Text
                 if (Properties.Settings.Default.DoRandomization_Text)
                 {
                     bw.Write("TEXT".ToCharArray());
@@ -458,7 +467,8 @@ namespace kotor_Randomizer_2
                     bw.Write((int)Properties.Settings.Default.TextSettingsValue);
 
                 }
-                // Other
+                #endregion
+                #region Other
                 if (Properties.Settings.Default.DoRandomization_Other)
                 {
                     bw.Write("OTHR".ToCharArray());
@@ -488,7 +498,11 @@ namespace kotor_Randomizer_2
 
                     bw.Write(Properties.Settings.Default.PolymorphMode);
                     bw.Write(Properties.Settings.Default.RandomizePazaakDecks);
+                    bw.Write(Properties.Settings.Default.RandomizePartyMembers);
+                    bw.Write(Properties.Settings.Default.RandomizeSwoopBoosters);
+                    bw.Write(Properties.Settings.Default.RandomizeSwoopObstacles);
                 }
+                #endregion
             }
         }
         #endregion

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -938,5 +938,29 @@ namespace kotor_Randomizer_2.Properties {
                 this["IgnoreOnceEdges"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RandomizeSwoopBoosters {
+            get {
+                return ((bool)(this["RandomizeSwoopBoosters"]));
+            }
+            set {
+                this["RandomizeSwoopBoosters"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RandomizeSwoopObstacles {
+            get {
+                return ((bool)(this["RandomizeSwoopObstacles"]));
+            }
+            set {
+                this["RandomizeSwoopObstacles"] = value;
+            }
+        }
     }
 }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -234,5 +234,11 @@
     <Setting Name="IgnoreOnceEdges" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="RandomizeSwoopBoosters" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="RandomizeSwoopObstacles" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Randomization/OtherRando.cs
+++ b/kotor Randomizer 2/Randomization/OtherRando.cs
@@ -334,11 +334,19 @@ namespace kotor_Randomizer_2
                 var boosters = Tracks.Where(x => !x.Item1.EndsWith("01")).ToList();
                 RandomizeCoordinates(boosters, minimum, maximum);
 
-                // Assign randomized values back to the full list.
-                var count = boosters.Count;
-                for (int i = 0; i < count; i++)
+                // Assign randomized values back to the full list, skipping any whose name ends in 01.
+                var trackCount = Tracks.Count;
+                int j = 0;
+                for (int i = 0; i < trackCount; i++)
                 {
-                    Tracks[i + 1] = boosters[i];
+                    if (Tracks[i].Item1.EndsWith("01"))
+                    {
+                        //j--; // Don't change j.
+                        continue;
+                    }
+
+                    Tracks[i] = boosters[j];
+                    j++;
                 }
             }
 

--- a/kotor Randomizer 2/Randomization/Randomize.cs
+++ b/kotor Randomizer 2/Randomization/Randomize.cs
@@ -70,5 +70,11 @@ namespace kotor_Randomizer_2
                 }
             }
         }
+
+        public static double GetRandomDouble(double min, double max)
+        {
+            if (min == max) return 0.0; // Handle 0 range without advancing the seed.
+            return Rng.NextDouble() * (max - min) + min;
+        }
     }
 }


### PR DESCRIPTION
This pull request is for enhancement #24.

I created a Layout class to parse the plain text file and randomize the position of layout objects. The feature is included under Other randomization and has two options that can both be enabled independently: booster pads and obstacles.

I also added tool tips to the Other randomization page to clean up the informative text for the other items. I added tips for swoop randomization as well - object randomization is not recommended since the visual doesn't change with the hitbox.

For the randomization, I chose to go with the simplicity of using a single set of min and max coordinates for the randomization. I used the overall min and max as listed in #24 for the largest variety. In the small amount of testing I've done, this gives objects at the edges of what the bike can reach during the race, but none that aren't inaccessible. Although, the possibility exists that items randomized on the Manaan swoops could be beyond the finish line, as it seems to be a little smaller than the other two tracks.