### PR TITLE
Added the option to overwrite DMCA music

### DIFF
--- a/Patch Sources/Patch Sources.csproj
+++ b/Patch Sources/Patch Sources.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A0BF410A-69C7-4ED2-BBCE-395047D3A8DD}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Patch_Sources</RootNamespace>
     <AssemblyName>Patch Sources</AssemblyName>
@@ -31,6 +31,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <None Include="k_pebn_galaxy.nss" />

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -250,6 +250,9 @@
             <setting name="IgnoreOnceEdges" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="RemoveDmcaMusic" serializeAs="String">
+                <value>False</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/Forms/SoundForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/SoundForm.Designer.cs
@@ -64,6 +64,7 @@
             this.bToggleAll = new System.Windows.Forms.Button();
             this.bTypeAll = new System.Windows.Forms.Button();
             this.bMaxAll = new System.Windows.Forms.Button();
+            this.cbRemoveDmca = new System.Windows.Forms.CheckBox();
             this.flpAreaMusic.SuspendLayout();
             this.flpCutsceneNoise.SuspendLayout();
             this.flpAmbientNoise.SuspendLayout();
@@ -485,12 +486,23 @@
             this.bMaxAll.UseVisualStyleBackColor = false;
             this.bMaxAll.Click += new System.EventHandler(this.bMaxAll_Click);
             // 
+            // cbRemoveDmca
+            // 
+            this.cbRemoveDmca.AutoSize = true;
+            this.cbRemoveDmca.Location = new System.Drawing.Point(45, 213);
+            this.cbRemoveDmca.Name = "cbRemoveDmca";
+            this.cbRemoveDmca.Size = new System.Drawing.Size(161, 17);
+            this.cbRemoveDmca.TabIndex = 22;
+            this.cbRemoveDmca.Text = "Overwrite likely DMCA music";
+            this.cbRemoveDmca.UseVisualStyleBackColor = true;
+            // 
             // SoundForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(331, 222);
+            this.ClientSize = new System.Drawing.Size(331, 243);
+            this.Controls.Add(this.cbRemoveDmca);
             this.Controls.Add(this.bMaxAll);
             this.Controls.Add(this.bTypeAll);
             this.Controls.Add(this.bToggleAll);
@@ -570,5 +582,6 @@
         private System.Windows.Forms.Button bToggleAll;
         private System.Windows.Forms.Button bTypeAll;
         private System.Windows.Forms.Button bMaxAll;
+        private System.Windows.Forms.CheckBox cbRemoveDmca;
     }
 }

--- a/kotor Randomizer 2/Forms/SoundForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/SoundForm.Designer.cs
@@ -77,7 +77,7 @@
             // 
             this.cbMixNpcParty.AutoSize = true;
             this.cbMixNpcParty.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbMixNpcParty.Location = new System.Drawing.Point(45, 190);
+            this.cbMixNpcParty.Location = new System.Drawing.Point(45, 214);
             this.cbMixNpcParty.Name = "cbMixNpcParty";
             this.cbMixNpcParty.Size = new System.Drawing.Size(200, 17);
             this.cbMixNpcParty.TabIndex = 8;
@@ -489,12 +489,13 @@
             // cbRemoveDmca
             // 
             this.cbRemoveDmca.AutoSize = true;
-            this.cbRemoveDmca.Location = new System.Drawing.Point(45, 213);
+            this.cbRemoveDmca.Location = new System.Drawing.Point(45, 191);
             this.cbRemoveDmca.Name = "cbRemoveDmca";
             this.cbRemoveDmca.Size = new System.Drawing.Size(161, 17);
             this.cbRemoveDmca.TabIndex = 22;
             this.cbRemoveDmca.Text = "Overwrite likely DMCA music";
             this.cbRemoveDmca.UseVisualStyleBackColor = true;
+            this.cbRemoveDmca.CheckedChanged += new System.EventHandler(this.cbRemoveDmca_CheckedChanged);
             // 
             // SoundForm
             // 

--- a/kotor Randomizer 2/Forms/SoundForm.cs
+++ b/kotor Randomizer 2/Forms/SoundForm.cs
@@ -25,6 +25,7 @@ namespace kotor_Randomizer_2
             //RandomizeNpcSounds = Properties.Settings.Default.RandomizeNpcSounds;
             RandomizeNpcSounds = RandomizationLevel.None; // Functionality Disabled
             RandomizePartySounds = (RandomizationLevel)Properties.Settings.Default.RandomizePartySounds;
+            cbRemoveDmca.Checked = Properties.Settings.Default.RemoveDmcaMusic;
 
             //MixNpcAndParty = Properties.Settings.Default.MixNpcAndPartySounds;
             MixNpcAndParty = false; // Functionality Disabled
@@ -439,6 +440,11 @@ namespace kotor_Randomizer_2
             {
                 rb.Checked = true;
             }
+        }
+
+        private void cbRemoveDmca_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.RemoveDmcaMusic = cbRemoveDmca.Checked;
         }
 
         #endregion

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -62,6 +62,7 @@ namespace kotor_Randomizer_2
             ItemRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_items.csv"));
             ModelRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_models.csv"));
             ModuleRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_modules.csv"));
+            SoundRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_music_sounds.csv"));
 
             MessageBox.Show("Spoiler logs created.");
         }

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -163,6 +163,7 @@ namespace kotor_Randomizer_2
                         Properties.Settings.Default.RandomizePartySounds = br.ReadInt32();
 
                         // Bools
+                        Properties.Settings.Default.RemoveDmcaMusic = br.ReadBoolean();
                         Properties.Settings.Default.MixNpcAndPartySounds = br.ReadBoolean();
                     }
                     #endregion
@@ -394,6 +395,7 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.RandomizeNpcSounds);
                     bw.Write(Properties.Settings.Default.RandomizePartySounds);
 
+                    bw.Write(Properties.Settings.Default.RemoveDmcaMusic);
                     bw.Write(Properties.Settings.Default.MixNpcAndPartySounds);
 
                 }

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -938,5 +938,17 @@ namespace kotor_Randomizer_2.Properties {
                 this["IgnoreOnceEdges"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RemoveDmcaMusic {
+            get {
+                return ((bool)(this["RemoveDmcaMusic"]));
+            }
+            set {
+                this["RemoveDmcaMusic"] = value;
+            }
+        }
     }
 }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -234,5 +234,8 @@
     <Setting Name="IgnoreOnceEdges" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="RemoveDmcaMusic" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -82,7 +82,26 @@ namespace kotor_Randomizer_2
                         Randomize.RestartRng();
                         curr_task = Properties.Resources.RandomizingMusicSound;
                         bwRandomizing.ReportProgress(curr_progress);
-                        CreateSoundBackups();
+
+                        // If music files are to be randomized, create backups.
+                        if (Properties.Settings.Default.RandomizeAreaMusic     != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizeAmbientNoise  != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizeBattleMusic   != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizeCutsceneNoise != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RemoveDmcaMusic)
+                        {
+                            CreateMusicBackups();
+                        }
+
+                        // If sound files are to be randomized, create backups.
+                        if (Properties.Settings.Default.RandomizeAmbientNoise != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizeBattleMusic  != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizeNpcSounds    != (int)RandomizationLevel.None ||
+                            Properties.Settings.Default.RandomizePartySounds  != (int)RandomizationLevel.None)
+                        {
+                            CreateSoundBackups();
+                        }
+
                         SoundRando.sound_rando(paths); // Run appropriate rando script.
                         sw.WriteLine(Properties.Resources.LogMusicSoundDone);
                         curr_progress += step_size;
@@ -263,9 +282,13 @@ namespace kotor_Randomizer_2
             paths.BackUpChitinFile();
         }
 
-        private void CreateSoundBackups()
+        private void CreateMusicBackups()
         {
             paths.BackUpMusicDirectory();
+        }
+
+        private void CreateSoundBackups()
+        {
             paths.BackUpSoundDirectory();
         }
 

--- a/kotor Randomizer 2/Randomization/Randomize.cs
+++ b/kotor Randomizer 2/Randomization/Randomize.cs
@@ -55,11 +55,12 @@ namespace kotor_Randomizer_2
             }
         }
 
-        public static void RandomizeFiles(IEnumerable<FileInfo> files, string outPath)
+        public static List<FileInfo> RandomizeFiles(IEnumerable<FileInfo> files, string outPath)
         {
-            if (files.Any())
+            var randList = files?.ToList() ?? new List<FileInfo>();
+
+            if (files?.Any() ?? false)
             {
-                var randList = files.ToList();
                 FisherYatesShuffle(randList);
 
                 int i = 0;
@@ -69,6 +70,8 @@ namespace kotor_Randomizer_2
                     ++i;
                 }
             }
+
+            return randList;
         }
     }
 }

--- a/kotor Randomizer 2/Randomization/SoundRando.cs
+++ b/kotor Randomizer 2/Randomization/SoundRando.cs
@@ -25,6 +25,11 @@ namespace kotor_Randomizer_2
                 areaMusic.AddRange(musicFiles.Where(f => f.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)));
             }
 
+            //if (false)
+            //{
+            //    areaMusic.RemoveAll(f => DmcaAreaMusic.Contains(f.Name));
+            //}
+
             switch ((RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic)
             {
                 case RandomizationLevel.Max:
@@ -188,13 +193,26 @@ namespace kotor_Randomizer_2
                 {
                     "mus_area_",
                     "mus_theme_",
-                    "57.",
-                    "credits.",
-                    "evil_ending.",
+                    "57.",          // LS ending BGM, Star Wars main theme
+                    "credits.",     // Star Wars main theme
+                    "evil_ending.", // DS ending BGM, Star Wars main theme
                 };
             }
         }
-        
+
+        public static List<string> DmcaAreaMusic
+        {
+            get
+            {
+                return new List<string>()
+                {
+                    "57.wav",
+                    "credits.wav",
+                    "evil_ending.wav",
+                };
+            }
+        }
+
         public static Regex RegexBattleMusic { get { return new Regex("mus_s?bat_", RegexOptions.Compiled | RegexOptions.IgnoreCase); } }
 
         public static List<string> PrefixListBattleMusic

--- a/kotor Randomizer 2/Randomization/SoundRando.cs
+++ b/kotor Randomizer 2/Randomization/SoundRando.cs
@@ -9,14 +9,22 @@ namespace kotor_Randomizer_2
     //This has absically been copied verbatim from what Glasnonck coded in the last rando, could probably be cleaned up, but I cannot be bothered 
     class SoundRando
     {
+        private static Dictionary<string, string> MusicLookupTable { get; set; } = new Dictionary<string, string>();
+        private static Dictionary<string, string> SoundLookupTable { get; set; } = new Dictionary<string, string>();
+
         public static void sound_rando(KPaths paths)
         {
-            var musicFiles = paths.FilesInMusicBackup;
-            var soundFiles = paths.FilesInSoundsBackup;
+            // Prepare lists for new randomization.
+            MusicLookupTable.Clear();
+            SoundLookupTable.Clear();
 
             // Get file collections
             List<FileInfo> maxMusic = new List<FileInfo>();
             List<FileInfo> maxSound = new List<FileInfo>();
+            List<FileInfo> musicFiles = new List<FileInfo>();
+            List<FileInfo> soundFiles = new List<FileInfo>();
+            if (Directory.Exists(paths.music_backup))  musicFiles = paths.FilesInMusicBackup.ToList();
+            if (Directory.Exists(paths.sounds_backup)) soundFiles = paths.FilesInSoundsBackup.ToList();
 
             // Area Music
             List<FileInfo> areaMusic = new List<FileInfo>();
@@ -25,10 +33,10 @@ namespace kotor_Randomizer_2
                 areaMusic.AddRange(musicFiles.Where(f => f.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)));
             }
 
-            //if (false)
-            //{
-            //    areaMusic.RemoveAll(f => DmcaAreaMusic.Contains(f.Name));
-            //}
+            if (Properties.Settings.Default.RemoveDmcaMusic)
+            {
+                areaMusic.RemoveAll(f => DmcaAreaMusic.Contains(f.Name));   // Remove DMCA music from the area list.
+            }
 
             switch ((RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic)
             {
@@ -36,7 +44,8 @@ namespace kotor_Randomizer_2
                     maxMusic.AddRange(areaMusic);
                     break;
                 case RandomizationLevel.Type:
-                    Randomize.RandomizeFiles(areaMusic, paths.music);
+                    var randList = Randomize.RandomizeFiles(areaMusic, paths.music);
+                    AddToMusicLookup(areaMusic, randList);
                     break;
                 case RandomizationLevel.Subtype:
                 case RandomizationLevel.None:
@@ -64,8 +73,11 @@ namespace kotor_Randomizer_2
                     maxSound.AddRange(ambientNoiseSound);
                     break;
                 case RandomizationLevel.Type:
-                    Randomize.RandomizeFiles(ambientNoiseMusic, paths.music);
-                    Randomize.RandomizeFiles(ambientNoiseSound, paths.sounds);
+                    var randList = Randomize.RandomizeFiles(ambientNoiseMusic, paths.music);
+                    AddToMusicLookup(ambientNoiseMusic, randList);
+
+                    randList = Randomize.RandomizeFiles(ambientNoiseSound, paths.sounds);
+                    AddToSoundLookup(ambientNoiseSound, randList);
                     break;
                 case RandomizationLevel.Subtype:
                 case RandomizationLevel.None:
@@ -84,8 +96,11 @@ namespace kotor_Randomizer_2
                     maxSound.AddRange(battleMusicEnd);
                     break;
                 case RandomizationLevel.Type:
-                    Randomize.RandomizeFiles(battleMusic, paths.music);
-                    Randomize.RandomizeFiles(battleMusicEnd, paths.sounds);
+                    var randList = Randomize.RandomizeFiles(battleMusic, paths.music);
+                    AddToMusicLookup(battleMusic, randList);
+
+                    randList = Randomize.RandomizeFiles(battleMusicEnd, paths.sounds);
+                    AddToSoundLookup(battleMusicEnd, randList);
                     break;
                 case RandomizationLevel.Subtype:
                 case RandomizationLevel.None:
@@ -103,7 +118,8 @@ namespace kotor_Randomizer_2
                     maxMusic.AddRange(cutsceneNoise);
                     break;
                 case RandomizationLevel.Type:
-                    Randomize.RandomizeFiles(cutsceneNoise, paths.music);
+                    var randList = Randomize.RandomizeFiles(cutsceneNoise, paths.music);
+                    AddToMusicLookup(cutsceneNoise, randList);
                     break;
                 case RandomizationLevel.Subtype:
                 case RandomizationLevel.None:
@@ -128,7 +144,8 @@ namespace kotor_Randomizer_2
                         maxSound.AddRange(partySounds);
                         break;
                     case RandomizationLevel.Type:
-                        Randomize.RandomizeFiles(partySounds, paths.sounds);
+                        var randList = Randomize.RandomizeFiles(partySounds, paths.sounds);
+                        AddToSoundLookup(partySounds, randList);
                         break;
                     case RandomizationLevel.Subtype:
                         RandomizeSoundActions(partySounds, paths.sounds);
@@ -157,31 +174,192 @@ namespace kotor_Randomizer_2
             //}
 
             // Max Randomizations
-            if (maxMusic.Any()) { Randomize.RandomizeFiles(maxMusic, paths.music); }
-            if (maxSound.Any()) { Randomize.RandomizeFiles(maxSound, paths.sounds); }
+            if (maxMusic.Any())
+            {
+                var randList = Randomize.RandomizeFiles(maxMusic, paths.music);
+                AddToMusicLookup(maxMusic, randList);
+            }
+            if (maxSound.Any())
+            {
+                var randList = Randomize.RandomizeFiles(maxSound, paths.sounds);
+                AddToSoundLookup(maxSound, randList);
+            }
+
+            // Overwrite DMCA music with alternatives
+            if (Properties.Settings.Default.RemoveDmcaMusic)
+            {
+                var orig = new List<FileInfo>();
+                var rand = new List<FileInfo>();
+                foreach (var fi in musicFiles.Where(f => DmcaAreaMusic.Contains(f.Name)))
+                {
+                    var replacement = areaMusic[Randomize.Rng.Next(areaMusic.Count)];
+                    File.Copy(replacement.FullName, Path.Combine(paths.music, fi.Name), true);
+
+                    orig.Add(fi);
+                    rand.Add(replacement);
+                }
+                AddToMusicLookup(orig, rand);
+            }
+        }
+
+        private static void AddToMusicLookup(List<FileInfo> original, List<FileInfo> randomized)
+        {
+            for (int i = 0; i < original.Count; i++)
+            {
+                if (MusicLookupTable.ContainsKey(original[i].Name))
+                {
+                    MusicLookupTable[original[i].Name] = randomized[i].Name;
+                }
+                else
+                {
+                    MusicLookupTable.Add(original[i].Name, randomized[i].Name);
+                }
+            }
+        }
+
+        private static void AddToSoundLookup(List<FileInfo> original, List<FileInfo> randomized)
+        {
+            for (int i = 0; i < original.Count; i++)
+            {
+                if (SoundLookupTable.ContainsKey(original[i].Name))
+                {
+                    SoundLookupTable[original[i].Name] = randomized[i].Name;
+                }
+                else
+                {
+                    SoundLookupTable.Add(original[i].Name, randomized[i].Name);
+                }
+            }
         }
 
         private static void RandomizeSoundActions(List<FileInfo> files, string outPath)
         {
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundAttack.IsMatch(f.Name)), outPath);       // ATK
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundBattle.IsMatch(f.Name)), outPath);       // BAT
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundLockAttempt.IsMatch(f.Name)), outPath);  // BLOCK
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundCriticalHit.IsMatch(f.Name)), outPath);  // CRIT
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundDead.IsMatch(f.Name)), outPath);         // DEAD
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundMineFound.IsMatch(f.Name)), outPath);    // DMIN
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundLockFailure.IsMatch(f.Name)), outPath);  // FLOCK
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundHit.IsMatch(f.Name)), outPath);          // HIT
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundMineSet.IsMatch(f.Name)), outPath);      // LMIN
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundLowHealth.IsMatch(f.Name)), outPath);    // LOW
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundMedicine.IsMatch(f.Name)), outPath);     // MED
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundPoison.IsMatch(f.Name)), outPath);       // POIS
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundSoloOff.IsMatch(f.Name)), outPath);      // RPRTY
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundSelect.IsMatch(f.Name)), outPath);       // SLCT
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundLockSuccess.IsMatch(f.Name)), outPath);  // SLOCK
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundSoloOn.IsMatch(f.Name)), outPath);       // SPRTY
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundSearch.IsMatch(f.Name)), outPath);       // SRCH
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundStealth.IsMatch(f.Name)), outPath);      // STLH
-            Randomize.RandomizeFiles(files.Where(f => SuffixSoundIneffective.IsMatch(f.Name)), outPath);  // TIA
+            var actionList = files.Where(f => SuffixSoundAttack.IsMatch(f.Name)).ToList();
+            var randList = Randomize.RandomizeFiles(actionList, outPath);   // ATK
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundBattle.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // BAT
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundLockAttempt.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // BLOCK
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundCriticalHit.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // CRIT
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundDead.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // DEAD
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundMineFound.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // DMIN
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundLockFailure.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // FLOCK
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundHit.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // HIT
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundMineSet.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // LMIN
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundLowHealth.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // LOW
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundMedicine.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // MED
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundPoison.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // POIS
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundSoloOff.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // RPRTY
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundSelect.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // SLCT
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundLockSuccess.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // SLOCK
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundSoloOn.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // SPRTY
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundSearch.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // SRCH
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundStealth.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // STLH
+            AddToSoundLookup(actionList, randList);
+
+            actionList = files.Where(f => SuffixSoundIneffective.IsMatch(f.Name)).ToList();
+            randList = Randomize.RandomizeFiles(actionList, outPath);       // TIA
+            AddToSoundLookup(actionList, randList);
+        }
+
+        public static void GenerateSpoilerLog(string path)
+        {
+            if (MusicLookupTable.Count == 0 &&
+                SoundLookupTable.Count == 0)
+            { return; }
+
+            using (StreamWriter sw = new StreamWriter(path))
+            {
+                sw.WriteLine($"Seed,{Properties.Settings.Default.Seed}");
+                sw.WriteLine();
+
+                sw.WriteLine($"Area Music,{(RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic}");
+                sw.WriteLine($"Battle Music,{(RandomizationLevel)Properties.Settings.Default.RandomizeBattleMusic}");
+                sw.WriteLine($"Ambient Noise,{(RandomizationLevel)Properties.Settings.Default.RandomizeAmbientNoise}");
+                sw.WriteLine($"Cutscene Noise,{(RandomizationLevel)Properties.Settings.Default.RandomizeCutsceneNoise}");
+                sw.WriteLine($"NPC Sounds,{(RandomizationLevel)Properties.Settings.Default.RandomizeNpcSounds}");
+                sw.WriteLine($"Party Sounds,{(RandomizationLevel)Properties.Settings.Default.RandomizePartySounds}");
+                sw.WriteLine($"Remove DMCA,{Properties.Settings.Default.RemoveDmcaMusic}");
+                sw.WriteLine($"Mix NPC and Party,{Properties.Settings.Default.MixNpcAndPartySounds}");
+                sw.WriteLine();
+
+                if (MusicLookupTable.Any())
+                {
+                    var sortedLookup = MusicLookupTable.OrderBy(kvp => kvp.Key);
+                    sw.WriteLine("Music");
+                    sw.WriteLine("Original,Randomized");
+
+                    foreach (var kvp in sortedLookup)
+                    {
+                        sw.WriteLine($"{kvp.Key},{kvp.Value}");
+                    }
+
+                    sw.WriteLine();
+                }
+
+                if (SoundLookupTable.Any())
+                {
+                    var sortedLookup = SoundLookupTable.OrderBy(kvp => kvp.Key);
+                    sw.WriteLine("Sound");
+                    sw.WriteLine("Original,Randomized");
+
+                    foreach (var kvp in sortedLookup)
+                    {
+                        sw.WriteLine($"{kvp.Key},{kvp.Value}");
+                    }
+
+                    sw.WriteLine();
+                }
+            }
         }
 
         //public static Regex PrefixAreaMusic { get { return new Regex("", RegexOptions.Compiled | RegexOptions.IgnoreCase); } }


### PR DESCRIPTION
This pull request fulfills the enhancement #6.

A few enhancements around music and sound randomization are included within this PR.

- The three credits music tracks can be overwritten with an alternative to reduce the likelihood of DMCA claims on videos of a randomized playthrough. This can be done with or without randomizing area music.
- This setting will be saved in or loaded from a preset file.
- A spoiler log will now be created for sound randomization if requested.
- Music randomization and sound randomization are treated separately (as much as possible) when it comes to creating backup folders. This will speed up randomization if only randomizing music and not sounds.