### PR TITLE
Merge spoiler files and generate spoilers for remaining categories

### DIFF
--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using System.IO;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
@@ -58,13 +59,42 @@ namespace kotor_Randomizer_2
             //if (Directory.Exists(spoilersPath)) { Directory.Delete(spoilersPath, true); }
             Directory.CreateDirectory(spoilersPath);
 
-            var timestamp = DateTime.Now.ToString("yy-MM-dd_HH-mm-ss");
-            ItemRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_items.csv"));
-            ModelRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_models.csv"));
-            ModuleRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_modules.csv"));
-            SoundRando.GenerateSpoilerLog(Path.Combine(spoilersPath, $"{timestamp}_music_sounds.csv"));
+            //var timestamp = DateTime.Now.ToString("yy-MM-dd_HH-mm-ss");
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss");
+            var filename = $"{timestamp}, Seed={Properties.Settings.Default.Seed}.xlsx";
+            var path = Path.Combine(spoilersPath, filename);
 
-            MessageBox.Show("Spoiler logs created.");
+            if (File.Exists(path)) { File.Delete(path); }
+
+            using (var workbook = new XLWorkbook())
+            {
+                ItemRando.GenerateSpoilerLog(workbook);
+                ModelRando.GenerateSpoilerLog(workbook);
+                ModuleRando.GenerateSpoilerLog(workbook);
+                SoundRando.GenerateSpoilerLog(workbook);
+                OtherRando.GenerateSpoilerLog(workbook);
+                TextRando.GenerateSpoilerLog(workbook);
+                TextureRando.GenerateSpoilerLog(workbook);
+                TwodaRandom.GenerateSpoilerLog(workbook);
+
+                // If any worksheets have been added, save the spoiler log.
+                if (workbook.Worksheets.Count > 0)
+                {
+                    System.Text.StringBuilder wsList = new System.Text.StringBuilder();
+                    foreach (var sheet in workbook.Worksheets)
+                    {
+                        wsList.Append($"{sheet.Name}, ");
+                    }
+                    wsList.Remove(wsList.Length - 2, 2);
+
+                    workbook.SaveAs(path);
+                    MessageBox.Show($"Spoiler logs created: {wsList.ToString()}");
+                }
+                else
+                {
+                    MessageBox.Show($"No spoiler logs created. Either the game has not been randomized, or the selected randomizations do not generate spoilers.");
+                }
+            }
         }
 
         #region  Events

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.IO;
 using KotOR_IO;
 using System.Text.RegularExpressions;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
@@ -197,6 +198,102 @@ namespace kotor_Randomizer_2
                 }
                 sw.WriteLine();
             }
+        }
+
+        internal static void Reset()
+        {
+            // Prepare lists for new randomization.
+            Max_Rando.Clear();
+            Type_Lists.Clear();
+            LookupTable.Clear();
+        }
+
+        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        {
+            if (LookupTable.Count == 0) { return; }
+            var ws = workbook.Worksheets.Add("Items");
+
+            int i = 1;
+            ws.Cell(i, 1).Value = "Seed";
+            ws.Cell(i, 2).Value = Properties.Settings.Default.Seed;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i += 2;     // Skip a row.
+
+            // Item Randomization Settings
+            ws.Cell(i, 1).Value = "Item Type";
+            ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            i++;
+
+            var settings = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("Armbands", ((RandomizationLevel)Properties.Settings.Default.RandomizeArmbands).ToString()),
+                new Tuple<string, string>("Armor", ((RandomizationLevel)Properties.Settings.Default.RandomizeArmor).ToString()),
+                new Tuple<string, string>("Belts", ((RandomizationLevel)Properties.Settings.Default.RandomizeBelts).ToString()),
+                new Tuple<string, string>("Blasters", ((RandomizationLevel)Properties.Settings.Default.RandomizeBlasters).ToString()),
+                new Tuple<string, string>("Creature Hides", ((RandomizationLevel)Properties.Settings.Default.RandomizeHides).ToString()),
+                new Tuple<string, string>("Creature Weapons", ((RandomizationLevel)Properties.Settings.Default.RandomizeCreature).ToString()),
+                new Tuple<string, string>("Droid Equipment", ((RandomizationLevel)Properties.Settings.Default.RandomizeDroid).ToString()),
+                new Tuple<string, string>("Gauntlets", ((RandomizationLevel)Properties.Settings.Default.RandomizeGloves).ToString()),
+                new Tuple<string, string>("Grenades", ((RandomizationLevel)Properties.Settings.Default.RandomizeGrenades).ToString()),
+                new Tuple<string, string>("Implants", ((RandomizationLevel)Properties.Settings.Default.RandomizeImplants).ToString()),
+                new Tuple<string, string>("Lightsabers", ((RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers).ToString()),
+                new Tuple<string, string>("Masks", ((RandomizationLevel)Properties.Settings.Default.RandomizeMask).ToString()),
+                new Tuple<string, string>("Melee Weapons", ((RandomizationLevel)Properties.Settings.Default.RandomizeMelee).ToString()),
+                new Tuple<string, string>("Mines", ((RandomizationLevel)Properties.Settings.Default.RandomizeMines).ToString()),
+                new Tuple<string, string>("Pazaak Cards", ((RandomizationLevel)Properties.Settings.Default.RandomizePaz).ToString()),
+                new Tuple<string, string>("Stims/Medpacs", ((RandomizationLevel)Properties.Settings.Default.RandomizeStims).ToString()),
+                new Tuple<string, string>("Upgrades/Crystals", ((RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade).ToString()),
+                new Tuple<string, string>("Various", ((RandomizationLevel)Properties.Settings.Default.RandomizeVarious).ToString()),
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            // Omitted Items
+            ws.Cell(i, 1).Value = "Omitted Items";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i++;
+
+            foreach (var item in Globals.OmitItems)
+            {
+                ws.Cell(i, 1).Value = item;
+                i++;
+            }
+            i++;    // Skip a row.
+
+            // Randomized Items
+            ws.Cell(i, 1).Value = "Has Changed";
+            ws.Cell(i, 2).Value = "Original";
+            ws.Cell(i, 3).Value = "Randomized";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            ws.Cell(i, 3).Style.Font.Bold = true;
+            i++;
+
+            var sortedLookup = LookupTable.OrderBy(kvp => kvp.Key);
+            foreach (var kvp in sortedLookup)
+            {
+                ws.Cell(i, 1).Value = (kvp.Key != kvp.Value).ToString();
+                ws.Cell(i, 2).Value = kvp.Key;
+                ws.Cell(i, 3).Value = kvp.Value;
+                if (kvp.Key != kvp.Value) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
+                else ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                i++;
+            }
+
+            // Resize Columns
+            ws.Column(1).AdjustToContents();
+            ws.Column(2).AdjustToContents();
+            ws.Column(3).AdjustToContents();
         }
 
         #region Regexes

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -211,7 +211,7 @@ namespace kotor_Randomizer_2
         public static void GenerateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
-            var ws = workbook.Worksheets.Add("Items");
+            var ws = workbook.Worksheets.Add("Item");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";
@@ -222,6 +222,8 @@ namespace kotor_Randomizer_2
             // Item Randomization Settings
             ws.Cell(i, 1).Value = "Item Type";
             ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             i++;
@@ -260,6 +262,7 @@ namespace kotor_Randomizer_2
 
             // Omitted Items
             ws.Cell(i, 1).Value = "Omitted Items";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             i++;
 
@@ -274,6 +277,9 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 1).Value = "Has Changed";
             ws.Cell(i, 2).Value = "Original";
             ws.Cell(i, 3).Value = "Randomized";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;

--- a/kotor Randomizer 2/Randomization/ModelRando.cs
+++ b/kotor Randomizer 2/Randomization/ModelRando.cs
@@ -195,7 +195,7 @@ namespace kotor_Randomizer_2
         public static void GenerateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
-            var ws = workbook.Worksheets.Add("Models");
+            var ws = workbook.Worksheets.Add("Model");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";
@@ -209,6 +209,10 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 2).Value = "Is Active";
             ws.Cell(i, 3).Value = "Omit Large";
             ws.Cell(i, 4).Value = "Omit Broken";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;
@@ -246,6 +250,10 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 2).Value = "Is Active";
             ws.Cell(i, 3).Value = "Omit Airlocks";
             ws.Cell(i, 4).Value = "Omit Broken";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;
@@ -280,6 +288,12 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 4).Value = "Has Changed";
             ws.Cell(i, 5).Value = "Original ID";
             ws.Cell(i, 6).Value = "Randomized ID";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 5).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 6).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;
@@ -288,8 +302,6 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 6).Style.Font.Bold = true;
             i++;
 
-            string prevMap = string.Empty;
-            int j = 0;
             List<XLColor> colors = new List<XLColor>()
             {
                 XLColor.Red,
@@ -299,6 +311,8 @@ namespace kotor_Randomizer_2
                 XLColor.Blue,
                 XLColor.Purple,
             };
+            string prevMap = string.Empty;
+            int j = colors.Count - 1;
 
             foreach (var map in LookupTable)
             {

--- a/kotor Randomizer 2/Randomization/ModelRando.cs
+++ b/kotor Randomizer 2/Randomization/ModelRando.cs
@@ -3,6 +3,7 @@ using System.IO;
 using KotOR_IO;
 using System.Collections.Generic;
 using System;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
@@ -183,6 +184,161 @@ namespace kotor_Randomizer_2
                 }
                 sw.WriteLine();
             }
+        }
+
+        internal static void Reset()
+        {
+            // Prepare lists for new randomization.
+            LookupTable.Clear();
+        }
+
+        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        {
+            if (LookupTable.Count == 0) { return; }
+            var ws = workbook.Worksheets.Add("Models");
+
+            int i = 1;
+            ws.Cell(i, 1).Value = "Seed";
+            ws.Cell(i, 2).Value = Properties.Settings.Default.Seed;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i += 2;     // Skip a row.
+
+            // Model Randomization Settings
+            //   Settings A
+            ws.Cell(i, 1).Value = "Model Type";
+            ws.Cell(i, 2).Value = "Is Active";
+            ws.Cell(i, 3).Value = "Omit Large";
+            ws.Cell(i, 4).Value = "Omit Broken";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            ws.Cell(i, 3).Style.Font.Bold = true;
+            ws.Cell(i, 4).Style.Font.Bold = true;
+            i++;
+
+            string charIsActive = ((Properties.Settings.Default.RandomizeCharModels & 1) > 0).ToString();
+            string charOmitFirst = ((Properties.Settings.Default.RandomizeCharModels & 2) > 0).ToString();
+            string charOmitSecond = ((Properties.Settings.Default.RandomizeCharModels & 4) > 0).ToString();
+
+            string modelIsActive = ((Properties.Settings.Default.RandomizePlaceModels & 1) > 0).ToString();
+            string modelOmitFirst = ((Properties.Settings.Default.RandomizePlaceModels & 2) > 0).ToString();
+            string modelOmitSecond = ((Properties.Settings.Default.RandomizePlaceModels & 4) > 0).ToString();
+
+            var settings = new List<Tuple<string, string, string, string>>()
+            {
+                new Tuple<string, string, string, string>("Character Models", charIsActive, charOmitFirst, charOmitSecond),
+                new Tuple<string, string, string, string>("Placeable Models", modelIsActive, modelOmitFirst, modelOmitSecond),
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 3).Value = setting.Item3;
+                ws.Cell(i, 4).Value = setting.Item4;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            //   Settings B
+            ws.Cell(i, 1).Value = "Model Type";
+            ws.Cell(i, 2).Value = "Is Active";
+            ws.Cell(i, 3).Value = "Omit Airlocks";
+            ws.Cell(i, 4).Value = "Omit Broken";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            ws.Cell(i, 3).Style.Font.Bold = true;
+            ws.Cell(i, 4).Style.Font.Bold = true;
+            i++;
+
+            string doorIsActive = ((Properties.Settings.Default.RandomizeDoorModels & 1) > 0).ToString();
+            string doorOmitFirst = ((Properties.Settings.Default.RandomizeDoorModels & 2) > 0).ToString();
+            string doorOmitSecond = ((Properties.Settings.Default.RandomizeDoorModels & 4) > 0).ToString();
+
+            settings = new List<Tuple<string, string, string, string>>()
+            {
+                new Tuple<string, string, string, string>("Door Models", doorIsActive, doorOmitFirst, doorOmitSecond),
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 3).Value = setting.Item3;
+                ws.Cell(i, 4).Value = setting.Item4;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            // Model Shuffle
+            ws.Cell(i, 1).Value = "Map Filename";
+            ws.Cell(i, 2).Value = "Model Type";
+            ws.Cell(i, 3).Value = "Model Label";
+            ws.Cell(i, 4).Value = "Has Changed";
+            ws.Cell(i, 5).Value = "Original ID";
+            ws.Cell(i, 6).Value = "Randomized ID";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            ws.Cell(i, 3).Style.Font.Bold = true;
+            ws.Cell(i, 4).Style.Font.Bold = true;
+            ws.Cell(i, 5).Style.Font.Bold = true;
+            ws.Cell(i, 6).Style.Font.Bold = true;
+            i++;
+
+            string prevMap = string.Empty;
+            int j = 0;
+            List<XLColor> colors = new List<XLColor>()
+            {
+                XLColor.Red,
+                XLColor.OrangePeel,
+                XLColor.Green,
+                XLColor.DeepSkyBlue,
+                XLColor.Blue,
+                XLColor.Purple,
+            };
+
+            foreach (var map in LookupTable)
+            {
+                foreach (var type in map.Value)
+                {
+                    foreach (var kvp in type.Value)
+                    {
+                        var hasChanged = kvp.Value.Item1 != kvp.Value.Item2;
+                        ws.Cell(i, 1).Value = map.Key;
+                        ws.Cell(i, 2).Value = type.Key;
+                        ws.Cell(i, 3).Value = kvp.Key;
+                        ws.Cell(i, 4).Value = hasChanged;
+                        ws.Cell(i, 5).Value = kvp.Value.Item1;
+                        ws.Cell(i, 6).Value = kvp.Value.Item2;
+
+                        if (prevMap != map.Key)
+                        {
+                            prevMap = map.Key;
+                            j = (j + 1) % colors.Count;
+                        }
+                        ws.Cell(i, 1).Style.Font.FontColor = colors[j];
+
+                        if (type.Key == "Door")      ws.Cell(i, 2).Style.Font.FontColor = XLColor.Blue;
+                        if (type.Key == "Character") ws.Cell(i, 2).Style.Font.FontColor = XLColor.Green;
+                        if (type.Key == "Placeable") ws.Cell(i, 2).Style.Font.FontColor = XLColor.Red;
+
+                        if (hasChanged) ws.Cell(i, 4).Style.Font.FontColor = XLColor.Green;
+                        else            ws.Cell(i, 4).Style.Font.FontColor = XLColor.Red;
+
+                        i++;
+                    }
+                }
+            }
+
+            // Resize Columns
+            ws.Column(1).AdjustToContents();
+            ws.Column(2).AdjustToContents();
+            ws.Column(3).AdjustToContents();
+            ws.Column(4).AdjustToContents();
+            ws.Column(5).AdjustToContents();
         }
     }
 }

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -565,7 +565,7 @@ namespace kotor_Randomizer_2
         public static void GenerateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
-            var ws = workbook.Worksheets.Add("Modules");
+            var ws = workbook.Worksheets.Add("Module");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";
@@ -576,6 +576,8 @@ namespace kotor_Randomizer_2
             // Module Randomization Settings
             ws.Cell(i, 1).Value = "Module Extra";
             ws.Cell(i, 2).Value = "Is Enabled";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             i++;
@@ -620,6 +622,11 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 3).Value = "Default Name";
             ws.Cell(i, 4).Value = "Randomized Code";
             ws.Cell(i, 5).Value = "Randomized Name";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 5).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -53,6 +53,7 @@ namespace kotor_Randomizer_2
                 sw.WriteLine(Properties.Resources.LogHeader);
                 Properties.Settings.Default.KotorIsRandomized = true;
                 Randomize.SetSeed(Properties.Settings.Default.Seed);    // Not sure when is the best time to set the seed.
+                ResetRandomizationCategories();
 
                 // Randomize the categories.
                 try
@@ -174,6 +175,18 @@ namespace kotor_Randomizer_2
             curr_progress += step_size;
         }
 
+        private void ResetRandomizationCategories()
+        {
+            ModuleRando.Reset();
+            ItemRando.Reset();
+            SoundRando.Reset();
+            ModelRando.Reset();
+            TextureRando.Reset();
+            TwodaRandom.Reset();
+            TextRando.Reset();
+            OtherRando.Reset();
+        }
+
         // Unused - I'm keeping this around In case I try to tackle the release config issues again.
         private void UnRando_new()
         {
@@ -249,6 +262,8 @@ namespace kotor_Randomizer_2
                 curr_task = Properties.Resources.TaskFinishing;
                 File.Delete(paths.RANDOMIZED_LOG);
                 Properties.Settings.Default.KotorIsRandomized = false;
+
+                ResetRandomizationCategories();
             }
             catch (Exception e)
             {

--- a/kotor Randomizer 2/Randomization/SoundRando.cs
+++ b/kotor Randomizer 2/Randomization/SoundRando.cs
@@ -375,7 +375,7 @@ namespace kotor_Randomizer_2
             if (MusicLookupTable.Count == 0 &&
                 SoundLookupTable.Count == 0)
             { return; }
-            var ws = workbook.Worksheets.Add("MusicSounds");
+            var ws = workbook.Worksheets.Add("MusicSound");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";
@@ -386,6 +386,8 @@ namespace kotor_Randomizer_2
             // Music and Sound Randomization Settings
             ws.Cell(i, 1).Value = "Music/Sound Type";
             ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             i++;
@@ -424,6 +426,9 @@ namespace kotor_Randomizer_2
                 ws.Cell(i, 1).Value = "Has Changed";
                 ws.Cell(i, 2).Value = "Original";
                 ws.Cell(i, 3).Value = "Randomized";
+                ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
                 ws.Cell(i, 1).Style.Font.Bold = true;
                 ws.Cell(i, 2).Style.Font.Bold = true;
                 ws.Cell(i, 3).Style.Font.Bold = true;

--- a/kotor Randomizer 2/Randomization/TextRando.cs
+++ b/kotor Randomizer 2/Randomization/TextRando.cs
@@ -14,6 +14,22 @@ namespace kotor_Randomizer_2
     {
         private const int TLK_STRING_COUNT = 49264;
 
+        /// <summary>
+        /// Lookup table for randomized dialogue entries.
+        /// Usage: EntriesLookupTable[Module.Name][RFile.Label] = List(Struct[text].StringRef, rand, Struct[VO_ResRef].Reference, rand, Struct[Sound].Reference, rand);
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, List<Tuple<int, int, string, string, string, string>>>> EntriesLookupTable { get; set; } = new Dictionary<string, Dictionary<string, List<Tuple<int, int, string, string, string, string>>>>();
+        /// <summary>
+        /// Lookup table for randomized dialogue replies.
+        /// Usage: RepliesLookupTable[Module.Name][RFile.Label] = List(Struct[text].StringRef, rand);
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, List<Tuple<int, int>>>> RepliesLookupTable { get; set; } = new Dictionary<string, Dictionary<string, List<Tuple<int, int>>>>();
+        /// <summary>
+        /// Lookup table for the randomized TLK table.
+        /// Usage: TlkLookupTable[Index] = (OldValue, RandomValue);
+        /// </summary>
+        private static Dictionary<int, Tuple<string, string>> TlkLookupTable { get; set; } = new Dictionary<int, Tuple<string, string>>();
+
         public static void text_rando(KPaths paths)
         {
             var settings = Properties.Settings.Default;
@@ -47,32 +63,64 @@ namespace kotor_Randomizer_2
                     {
                         foreach (GFF.STRUCT S in (g.Top_Level.Fields.Where(x => x.Label == "EntryList").FirstOrDefault() as GFF.LIST).Structs)
                         {
-                            if ((S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef != -1) //Avoid averwriting dialogue end indicators, and animation nodes
+                            if ((S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef != -1) // Avoid overwriting dialogue end indicators, and animation nodes
                             {
-                                int str_ref = 0; //Find valid string
+                                int str_ref = 0; // Find valid string
                                 while (t.String_Data_Table[str_ref].SoundResRef == "" || t.String_Data_Table[str_ref].SoundResRef[0] == '_' || t.String_Data_Table[str_ref].SoundResRef.ToLower().Contains("comp")) //Ensure the string we have has a sound to go with it, starting with undescord means it's player dialogue, which doesn't have audio in this game
                                 {
                                     str_ref = Randomize.Rng.Next(TLK_STRING_COUNT);
                                 }
 
+                                if (!EntriesLookupTable.ContainsKey(fi.Name))
+                                    EntriesLookupTable.Add(fi.Name, new Dictionary<string, List<Tuple<int, int, string, string, string, string>>>());
+                                if (!EntriesLookupTable[fi.Name].ContainsKey(RF.Label))
+                                    EntriesLookupTable[fi.Name].Add(RF.Label, new List<Tuple<int, int, string, string, string, string>>());
+
                                 // Sound and Text Matching
                                 if (SoundMatching)
                                 {
-                                    (S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef = str_ref;
+                                    var text = S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString;
+                                    int textOrig = text.StringRef;
+                                    int textRand = str_ref;
+                                    text.StringRef = str_ref;
+
+                                    string VORefOrig = "";
+                                    string VORefRand = "";
+                                    string SoundOrig = "";
+                                    string SoundRand = "";
+
                                     try
                                     {
-                                        (S.Fields.Where(x => x.Label == "VO_ResRef").FirstOrDefault() as GFF.ResRef).Reference = t.String_Data_Table[str_ref].SoundResRef;
+                                        var voResRef = S.Fields.Where(x => x.Label == "VO_ResRef").FirstOrDefault() as GFF.ResRef;
+                                        VORefOrig = voResRef.Reference;
+                                        VORefRand = t.String_Data_Table[str_ref].SoundResRef;
+                                        voResRef.Reference = VORefRand;
                                     }
-                                    catch { }
+                                    catch
+                                    {
+                                        VORefOrig = "";
+                                        VORefRand = "";
+                                    }
                                     try
                                     {
-                                        (S.Fields.Where(x => x.Label == "Sound").FirstOrDefault() as GFF.ResRef).Reference = t.String_Data_Table[str_ref].SoundResRef;
+                                        var sound = S.Fields.Where(x => x.Label == "Sound").FirstOrDefault() as GFF.ResRef;
+                                        SoundOrig = sound.Reference;
+                                        SoundRand = t.String_Data_Table[str_ref].SoundResRef;
+                                        sound.Reference = SoundRand;
                                     }
-                                    catch { } //If both VO_ResRef and Sound Fail we ignore the entry
+                                    catch
+                                    {
+                                        SoundOrig = "";
+                                        SoundRand = "";
+                                    } // If both VO_ResRef and Sound Fail we ignore the entry
+
+                                    EntriesLookupTable[fi.Name][RF.Label].Add(new Tuple<int, int, string, string, string, string>(textOrig, textRand, VORefOrig, VORefRand, SoundOrig, SoundRand));
                                 }
                                 else
                                 {
-                                    (S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef = str_ref;
+                                    var text = S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString;
+                                    EntriesLookupTable[fi.Name][RF.Label].Add(new Tuple<int, int, string, string, string, string>(text.StringRef, str_ref, "", "", "", ""));
+                                    text.StringRef = str_ref;
                                 }
                             }
                         }
@@ -85,8 +133,15 @@ namespace kotor_Randomizer_2
                         {
                             if ((S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef != -1) //Avoid overwriting dialogue end indicators, and animation nodes
                             {
+                                if (!RepliesLookupTable.ContainsKey(fi.Name))
+                                    RepliesLookupTable.Add(fi.Name, new Dictionary<string, List<Tuple<int, int>>>());
+                                if (!RepliesLookupTable[fi.Name].ContainsKey(RF.Label))
+                                    RepliesLookupTable[fi.Name].Add(RF.Label, new List<Tuple<int, int>>());
+
                                 int str_ref = Randomize.Rng.Next(49264);
-                                (S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString).StringRef = str_ref;
+                                var text = S.Fields.Where(x => x.Label == "Text").FirstOrDefault() as GFF.CExoLocString;
+                                RepliesLookupTable[fi.Name][RF.Label].Add(new Tuple<int, int>(text.StringRef, str_ref));
+                                text.StringRef = str_ref;
                             }
                         }
                     }
@@ -117,8 +172,12 @@ namespace kotor_Randomizer_2
                         while (index_offset == 0)
                         {
                             index_offset = Randomize.Rng.Next(-5, 5);
-                        } 
-                        t.String_Data_Table[i] = t_ordered.String_Data_Table[t_ordered.String_Data_Table.FindIndex(x => x.StringText == t.String_Data_Table[i].StringText) + index_offset]; //Could get faster execution time by matching the strings by lenght instead of text, but then there would be bias towards strings earlier in each lenght bracket
+                        }
+
+                        // Could get faster execution time by matching the strings by lenght instead of text, but then there would be bias towards strings earlier in each lenght bracket.
+                        var randomString = t_ordered.String_Data_Table[t_ordered.String_Data_Table.FindIndex(x => x.StringText == t.String_Data_Table[i].StringText) + index_offset];
+                        TlkLookupTable.Add(i, new Tuple<string, string>(t.String_Data_Table[i].StringText, randomString.StringText));
+                        t.String_Data_Table[i] = randomString;
                     }
                     catch (Exception ex)
                     {
@@ -136,7 +195,13 @@ namespace kotor_Randomizer_2
             }
             else
             {
+                TLK t_orig = new TLK(paths.dialog);
                 Randomize.FisherYatesShuffle(t.String_Data_Table);
+
+                for (int i = 0; i < t.String_Data_Table.Count; i++)
+                {
+                    TlkLookupTable.Add(i, new Tuple<string, string>(t_orig.String_Data_Table[i].StringText, t.String_Data_Table[i].StringText));
+                }
             }
 
             t.WriteToFile(paths.dialog);
@@ -144,12 +209,275 @@ namespace kotor_Randomizer_2
 
         internal static void Reset()
         {
-            // method stub
+            TlkLookupTable.Clear();
+            EntriesLookupTable.Clear();
+            RepliesLookupTable.Clear();
         }
 
         internal static void GenerateSpoilerLog(XLWorkbook workbook)
         {
-            return;
+            if (TlkLookupTable.Count == 0     &&
+                EntriesLookupTable.Count == 0 &&
+                RepliesLookupTable.Count == 0 )
+            { return; }
+            var ws = workbook.Worksheets.Add("Text");
+
+            int i = 1;
+            ws.Cell(i, 1).Value = "Seed";
+            ws.Cell(i, 2).Value = Properties.Settings.Default.Seed;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i += 2;     // Skip a row.
+
+            // Text Randomization Settings
+            ws.Cell(i, 1).Value = "Rando Type";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Value = "Is Enabled";
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            i++;
+
+            var textSetting = Properties.Settings.Default.TextSettingsValue;
+            var settings = new List<Tuple<string, bool>>()
+            {
+                new Tuple<string, bool>("Dialogue Randomization", textSetting.HasFlag(TextSettings.RandoDialogEntries) || textSetting.HasFlag(TextSettings.RandoDialogReplies)),
+                new Tuple<string, bool>("Randomize Entries", textSetting.HasFlag(TextSettings.RandoDialogEntries)),
+                new Tuple<string, bool>("Randomize Replies", textSetting.HasFlag(TextSettings.RandoDialogReplies)),
+                new Tuple<string, bool>("Match Entry Sounds", textSetting.HasFlag(TextSettings.MatchEntrySoundsWText)),
+                new Tuple<string, bool>("Randomize Additional Text", textSetting.HasFlag(TextSettings.RandoFullTLK)),
+                new Tuple<string, bool>("Match Text Length", textSetting.HasFlag(TextSettings.MatchSimLengthStrings)),
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            var jMax = 2;
+
+            // Entries
+            if (EntriesLookupTable.Any())
+            {
+                ws.Cell(i, 1).Value = "Entries Randomization";
+                ws.Cell(i, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                ws.Cell(i, 1).Style.Font.Bold = true;
+                ws.Range(i, 1, i, 3).Merge();
+                i++;
+
+                // Column Headings
+                int j = 0;
+                ws.Cell(i, ++j).Value = "Module Name";
+                ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Font.Italic = true;
+                ws.Cell(i, ++j).Value = "RFile Label";
+                ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Font.Italic = true;
+                ws.Cell(i, ++j).Value = "Orig StrRef";
+                ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Font.Italic = true;
+                ws.Cell(i, ++j).Value = "Rand StrRef";
+                ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, j).Style.Font.Italic = true;
+
+                if (textSetting.HasFlag(TextSettings.MatchEntrySoundsWText))
+                {
+                    ws.Cell(i, ++j).Value = "Orig VO_Ref";
+                    ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Font.Italic = true;
+                    ws.Cell(i, ++j).Value = "Rand VO_Ref";
+                    ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Font.Italic = true;
+                    ws.Cell(i, ++j).Value = "Orig Sound";
+                    ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Font.Italic = true;
+                    ws.Cell(i, ++j).Value = "Rand Sound";
+                    ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Font.Italic = true;
+                }
+
+                if (jMax < j) jMax = j;
+                i++;
+
+                List<XLColor> colors = new List<XLColor>()
+                {
+                    XLColor.Red,
+                    XLColor.OrangePeel,
+                    XLColor.Green,
+                    XLColor.DeepSkyBlue,
+                    XLColor.Blue,
+                    XLColor.Purple,
+                };
+                string prevMap = string.Empty;
+                int c = colors.Count - 1;
+
+                foreach (var map in EntriesLookupTable)
+                {
+                    foreach (var rfile in map.Value)
+                    {
+                        foreach (var set in rfile.Value)
+                        {
+                            ws.Cell(i, 1).Value = map.Key;
+                            ws.Cell(i, 2).Value = rfile.Key;
+                            ws.Cell(i, 3).Value = set.Item1;
+                            ws.Cell(i, 4).Value = set.Item2;
+                            if (textSetting.HasFlag(TextSettings.MatchEntrySoundsWText))
+                            {
+                                ws.Cell(i, 5).Value = set.Item3;
+                                ws.Cell(i, 6).Value = set.Item4;
+                                ws.Cell(i, 7).Value = set.Item5;
+                                ws.Cell(i, 8).Value = set.Item6;
+                                ws.Cell(i, 6).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                                ws.Cell(i, 8).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                            }
+
+                            if (prevMap != map.Key)
+                            {
+                                prevMap = map.Key;
+                                c = (c + 1) % colors.Count;
+                            }
+                            ws.Cell(i, 1).Style.Font.FontColor = colors[c];
+                            ws.Cell(i, 2).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                            ws.Cell(i, 4).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+
+                            i++;
+                        }
+                    }
+                }
+
+                i++;    // Skip a row.
+            }
+
+            // Replies
+            if (RepliesLookupTable.Any())
+            {
+                ws.Cell(i, 1).Value = "Replies Randomization";
+                ws.Cell(i, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                ws.Cell(i, 1).Style.Font.Bold = true;
+                ws.Range(i, 1, i, 3).Merge();
+                i++;
+
+                ws.Cell(i, 1).Value = "Module Name";
+                ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                ws.Cell(i, 2).Value = "RFile Label";
+                ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 2).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 2).Style.Font.Italic = true;
+                ws.Cell(i, 3).Value = "Orig StrRef";
+                ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 3).Style.Font.Italic = true;
+                ws.Cell(i, 4).Value = "Rand StrRef";
+                ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 4).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 4).Style.Font.Italic = true;
+
+                if (jMax < 4) jMax = 4;
+                i++;
+
+                List<XLColor> colors = new List<XLColor>()
+                {
+                    XLColor.Red,
+                    XLColor.OrangePeel,
+                    XLColor.Green,
+                    XLColor.DeepSkyBlue,
+                    XLColor.Blue,
+                    XLColor.Purple,
+                };
+                string prevMap = string.Empty;
+                int c = colors.Count - 1;
+
+                foreach (var map in RepliesLookupTable)
+                {
+                    foreach (var rfile in map.Value)
+                    {
+                        foreach (var set in rfile.Value)
+                        {
+                            ws.Cell(i, 1).Value = map.Key;
+                            ws.Cell(i, 2).Value = rfile.Key;
+                            ws.Cell(i, 3).Value = set.Item1;
+                            ws.Cell(i, 4).Value = set.Item2;
+
+                            if (prevMap != map.Key)
+                            {
+                                prevMap = map.Key;
+                                c = (c + 1) % colors.Count;
+                            }
+                            ws.Cell(i, 1).Style.Font.FontColor = colors[c];
+                            ws.Cell(i, 2).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                            ws.Cell(i, 4).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+
+                            i++;
+                        }
+                    }
+                }
+
+                i++;    // Skip a row.
+            }
+
+            // TLK File
+            if (TlkLookupTable.Any())
+            {
+                ws.Cell(i, 1).Value = "Additional Randomization";
+                ws.Cell(i, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                ws.Cell(i, 1).Style.Font.Bold = true;
+                ws.Range(i, 1, i, 3).Merge();
+                i++;
+
+                ws.Cell(i, 1).Value = "Table Index";
+                ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                ws.Cell(i, 2).Value = "Orig Text";
+                ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 2).Style.Font.Italic = true;
+                ws.Range(i, 2, i, 3).Merge();
+                ws.Cell(i, 4).Value = "Rand Text";
+                ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                ws.Cell(i, 4).Style.Font.Italic = true;
+                ws.Range(i, 4, i, 5).Merge();
+
+                if (jMax < 5) jMax = 5;
+                i++;
+
+                foreach (var index in TlkLookupTable)
+                {
+                    const int MAX_STR_LENGTH = 100;
+
+                    ws.Cell(i, 1).Value = index.Key;
+
+                    if (index.Value.Item1.Length > MAX_STR_LENGTH)
+                        ws.Cell(i, 2).Value = $"{index.Value.Item1.Substring(0, MAX_STR_LENGTH)}...";
+                    else
+                        ws.Cell(i, 2).Value = index.Value.Item1;
+
+
+                    if (index.Value.Item2.Length > MAX_STR_LENGTH)
+                        ws.Cell(i, 4).Value = $"{index.Value.Item2.Substring(0, MAX_STR_LENGTH)}...";
+                    else
+                        ws.Cell(i, 4).Value = index.Value.Item2;
+
+                    ws.Cell(i, 2).Style.Alignment.WrapText = true;
+                    ws.Range(i, 2, i, 3).Merge();
+                    ws.Cell(i, 4).Style.Alignment.WrapText = true;
+                    ws.Range(i, 4, i, 5).Merge();
+
+                    i++;
+                }
+
+                i++;    // Skip a row.
+            }
+
+            // Adjust columns.
+            for (int c = 1; c <= jMax; c++)
+            {
+                ws.Column(c).AdjustToContents();
+            }
         }
     }
 }

--- a/kotor Randomizer 2/Randomization/TextRando.cs
+++ b/kotor Randomizer 2/Randomization/TextRando.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using KotOR_IO;
 using System.IO;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
@@ -141,5 +142,14 @@ namespace kotor_Randomizer_2
             t.WriteToFile(paths.dialog);
         }
 
+        internal static void Reset()
+        {
+            // method stub
+        }
+
+        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        {
+            return;
+        }
     }
 }

--- a/kotor Randomizer 2/Randomization/TextureRando.cs
+++ b/kotor Randomizer 2/Randomization/TextureRando.cs
@@ -191,7 +191,7 @@ namespace kotor_Randomizer_2
         internal static void GenerateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
-            var ws = workbook.Worksheets.Add("Textures");
+            var ws = workbook.Worksheets.Add("Texture");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";
@@ -222,7 +222,9 @@ namespace kotor_Randomizer_2
 
             ws.Cell(i, 1).Value = "Texture Type";
             ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 2).Style.Font.Bold = true;
             i++;
 
@@ -261,6 +263,11 @@ namespace kotor_Randomizer_2
             ws.Cell(i, 3).Value = "Orig Ref";
             ws.Cell(i, 4).Value = "Rand ID";
             ws.Cell(i, 5).Value = "Rand Ref";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 5).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 1).Style.Font.Bold = true;
             ws.Cell(i, 2).Style.Font.Bold = true;
             ws.Cell(i, 3).Style.Font.Bold = true;

--- a/kotor Randomizer 2/Randomization/TextureRando.cs
+++ b/kotor Randomizer 2/Randomization/TextureRando.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using KotOR_IO;
 using System.IO;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
@@ -14,6 +15,17 @@ namespace kotor_Randomizer_2
         private static List<int> MaxRando { get; } = new List<int>();
 
         private static List<List<int>> TypeLists { get; } = new List<List<int>>();
+
+        /// <summary>
+        /// Lookup table for how models are randomized.
+        /// Usage: LookupTable[OriginalID] = RandomizedID;
+        /// </summary>
+        private static Dictionary<int, int> LookupTable { get; set; } = new Dictionary<int, int>();
+
+        /// <summary>
+        /// Lookup table for the name of each Texture ID.
+        /// </summary>
+        private static Dictionary<int, string> NameLookup { get; set; } = new Dictionary<int, string>();
 
         #region Regexes
         private static readonly Regex RegexCubeMaps = new Regex("^CM_", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -55,6 +67,12 @@ namespace kotor_Randomizer_2
 
             ERF e = new ERF(paths.TexturePacks + pack_name);
 
+            foreach (var key in e.Key_List)
+            {
+                if (!NameLookup.ContainsKey(key.ResID))
+                    NameLookup.Add(key.ResID, key.ResRef);
+            }
+
             // Handle categories.
             HandleCategory(e, RegexCubeMaps, Properties.Settings.Default.TextureRandomizeCubeMaps);
             HandleCategory(e, RegexCreatures, Properties.Settings.Default.TextureRandomizeCreatures);
@@ -91,6 +109,7 @@ namespace kotor_Randomizer_2
             int j = 0;
             foreach (ERF.Key k in e.Key_List.Where(x => Max_Rando_Iterator.Contains(x.ResID)))
             {
+                LookupTable.Add(k.ResID, MaxRando[j]);
                 k.ResID = MaxRando[j];
                 j++;
             }
@@ -103,6 +122,7 @@ namespace kotor_Randomizer_2
                 j = 0;
                 foreach (ERF.Key k in e.Key_List.Where(x => li.Contains(x.ResID)))
                 {
+                    LookupTable.Add(k.ResID, type_copy[j]);
                     k.ResID = type_copy[j];
                     j++;
                 }
@@ -157,6 +177,119 @@ namespace kotor_Randomizer_2
                     MaxRando.AddRange(e.Key_List.Where(x => r.IsMatch(x.ResRef) && !Is_Forbidden(x.ResRef)).Select(x => x.ResID));
                     break;
             }
+        }
+
+        internal static void Reset()
+        {
+            // Prepare lists for new randomization.
+            MaxRando.Clear();
+            TypeLists.Clear();
+            LookupTable.Clear();
+            NameLookup.Clear();
+        }
+
+        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        {
+            if (LookupTable.Count == 0) { return; }
+            var ws = workbook.Worksheets.Add("Textures");
+
+            int i = 1;
+            ws.Cell(i, 1).Value = "Seed";
+            ws.Cell(i, 2).Value = Properties.Settings.Default.Seed;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i++;
+
+            // Texture Randomization Settings
+            string texturePack = "";
+            switch (Properties.Settings.Default.TexturePack)
+            {
+                default:
+                case 0:
+                    texturePack = "High Quality";
+                    break;
+                case 1:
+                    texturePack = "Med Quality";
+                    break;
+                case 2:
+                    texturePack = "Low Quality";
+                    break;
+            }
+
+            ws.Cell(i, 1).Value = "Texture Pack";
+            ws.Cell(i, 2).Value = texturePack;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i += 2;     // Skip a row.
+
+            ws.Cell(i, 1).Value = "Texture Type";
+            ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            i++;
+
+            var settings = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("Cube Maps", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeCubeMaps).ToString()),
+                new Tuple<string, string>("Creatures", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeCreatures).ToString()),
+                new Tuple<string, string>("Effects", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeEffects).ToString()),
+                new Tuple<string, string>("Items", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeItems).ToString()),
+                new Tuple<string, string>("Planetary", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlanetary).ToString()),
+                new Tuple<string, string>("NPC", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeNPC).ToString()),
+                new Tuple<string, string>("Player Heads", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayHeads).ToString()),
+                new Tuple<string, string>("Player Bodies", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayBodies).ToString()),
+                new Tuple<string, string>("Placeables", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlaceables).ToString()),
+                new Tuple<string, string>("Party", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeParty).ToString()),
+                new Tuple<string, string>("Stunt", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeStunt).ToString()),
+                new Tuple<string, string>("Vehicles", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeVehicles).ToString()),
+                new Tuple<string, string>("Weapons", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeWeapons).ToString()),
+                new Tuple<string, string>("Other", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeOther).ToString()),
+                new Tuple<string, string>("", ""),  // Skip a row.
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            // Texture Shuffle
+            ws.Cell(i, 1).Value = "Has Changed";
+            ws.Cell(i, 2).Value = "Orig ID";
+            ws.Cell(i, 3).Value = "Orig Ref";
+            ws.Cell(i, 4).Value = "Rand ID";
+            ws.Cell(i, 5).Value = "Rand Ref";
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            ws.Cell(i, 3).Style.Font.Bold = true;
+            ws.Cell(i, 4).Style.Font.Bold = true;
+            ws.Cell(i, 5).Style.Font.Bold = true;
+            i++;
+
+            foreach (var kvp in LookupTable)
+            {
+                var hasChanged = kvp.Key != kvp.Value;
+                ws.Cell(i, 1).Value = hasChanged;
+                ws.Cell(i, 2).Value = kvp.Key;
+                if (NameLookup.ContainsKey(kvp.Key))
+                    ws.Cell(i, 3).Value = NameLookup[kvp.Key];
+                ws.Cell(i, 4).Value = kvp.Value;
+                if (NameLookup.ContainsKey(kvp.Value))
+                    ws.Cell(i, 5).Value = NameLookup[kvp.Value];
+
+                if (hasChanged) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
+                else            ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                i++;
+            }
+
+            // Resize Columns
+            ws.Column(1).AdjustToContents();
+            ws.Column(2).AdjustToContents();
+            ws.Column(3).AdjustToContents();
+            ws.Column(4).AdjustToContents();
+            ws.Column(5).AdjustToContents();
         }
     }
 }

--- a/kotor Randomizer 2/Randomization/TwodaRandom.cs
+++ b/kotor Randomizer 2/Randomization/TwodaRandom.cs
@@ -3,11 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using KotOR_IO;
+using ClosedXML.Excel;
 
 namespace kotor_Randomizer_2
 {
     public static class TwodaRandom
     {
+        /// <summary>
+        /// Lookup table for how 2DAs are randomized.
+        /// Usage: LookupTable[2DA][col_name] = (OriginalData, RandomizedData);
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, List<Tuple<string, string>>>> LookupTable { get; set; } = new Dictionary<string, Dictionary<string, List<Tuple<string, string>>>>();
+
         public static void Twoda_rando(KPaths paths)
         {
             BIF b = new BIF(Path.Combine(paths.data, "2da.bif"));
@@ -17,13 +24,108 @@ namespace kotor_Randomizer_2
             foreach (BIF.VariableResourceEntry VRE in b.VariableResourceTable.Where(x => Globals.Selected2DAs.Keys.Contains(x.ResRef)))
             {
                 TwoDA t = new TwoDA(VRE.EntryData, VRE.ResRef);
+                if (!LookupTable.ContainsKey(VRE.ResRef))
+                {
+                    // Add 2DA to the table.
+                    LookupTable.Add(VRE.ResRef, new Dictionary<string, List<Tuple<string, string>>>());
+                }
 
                 foreach (string col in Globals.Selected2DAs[VRE.ResRef])
                 {
-                    Randomize.FisherYatesShuffle(t.Data[col]);
+                    if (!LookupTable[VRE.ResRef].ContainsKey(col))
+                    {
+                        // Add column to the table.
+                        LookupTable[VRE.ResRef].Add(col, new List<Tuple<string, string>>());
+                    }
+
+                    var old = t.Data[col].ToList();             // Save list of old data.
+                    Randomize.FisherYatesShuffle(t.Data[col]);  // Randomize 2DA column data.
+
+                    for (int i = 0; i < old.Count; i++)
+                    {
+                        // Add old and new data to the table.
+                        LookupTable[VRE.ResRef][col].Add(new Tuple<string, string>(old[i], t.Data[col][i]));
+                    }
                 }
 
-                t.WriteToDirectory(paths.Override);
+                t.WriteToDirectory(paths.Override); // Write new 2DA data to file.
+            }
+        }
+
+        internal static void Reset()
+        {
+            // Prepare lists for new randomization.
+            LookupTable.Clear();
+        }
+
+        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        {
+            if (LookupTable.Count == 0) { return; }
+            var ws = workbook.Worksheets.Add("TwoDAs");
+
+            int i = 1;
+            ws.Cell(i, 1).Value = "Seed";
+            ws.Cell(i, 2).Value = Properties.Settings.Default.Seed;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            i += 2;     // Skip a row;
+
+            // TwoDA Randomization
+            const string ORIGINAL = "Orig";
+            const string RANDOM   = "Rand";
+
+            int iDone = i;
+            int j = 1;
+            int jMax = 1;
+
+            foreach (var twoDA in LookupTable)
+            {
+                // TwoDA Table Header
+                ws.Cell(i, 1).Value = twoDA.Key;
+                ws.Cell(i, 1).Style.Font.Bold = true;
+                ws.Cell(i, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                ws.Range(i, 1, i, 2).Merge();
+                i++;
+
+                var iStart = i;
+
+                foreach (var col in twoDA.Value)
+                {
+                    if (jMax < j) jMax = j + 1;     // Remember the width of the widest table.
+
+                    // Column Headers
+                    i = iStart;
+                    ws.Cell(i, j).Value = $"{col.Key} {ORIGINAL}";
+                    ws.Cell(i, j).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j).Style.Font.Italic = true;
+                    ws.Cell(i, j+1).Value = $"{col.Key} {RANDOM}";
+                    ws.Cell(i, j+1).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j+1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+                    ws.Cell(i, j+1).Style.Font.Italic = true;
+                    i++;
+
+                    foreach (var row in col.Value)
+                    {
+                        // Row Data
+                        ws.Cell(i, j).Value = row.Item1;
+                        ws.Cell(i, j).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+                        ws.Cell(i, j+1).Value = row.Item2;
+                        ws.Cell(i, j+1).Style.Border.RightBorder = XLBorderStyleValues.Thin;
+                        i++;
+                    }
+
+                    j += 2;     // Move to the next pair of columns.
+                    if (iDone < i) iDone = i;   // Remember the length of this table.
+                }
+
+                i = iDone + 1;  // Skip a row.
+                j = 1;          // Reset to column A.
+            }
+
+            // Adjust columns.
+            for (int c = 1; c <= jMax; c++)
+            {
+                ws.Column(c).AdjustToContents();
             }
         }
     }

--- a/kotor Randomizer 2/Randomization/TwodaRandom.cs
+++ b/kotor Randomizer 2/Randomization/TwodaRandom.cs
@@ -61,7 +61,7 @@ namespace kotor_Randomizer_2
         internal static void GenerateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
-            var ws = workbook.Worksheets.Add("TwoDAs");
+            var ws = workbook.Worksheets.Add("TwoDA");
 
             int i = 1;
             ws.Cell(i, 1).Value = "Seed";

--- a/kotor Randomizer 2/kotor Randomizer 2.csproj
+++ b/kotor Randomizer 2/kotor Randomizer 2.csproj
@@ -67,11 +67,21 @@
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClosedXML, Version=0.95.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.95.4\lib\net40\ClosedXML.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="ExcelNumberFormat, Version=1.0.10.0, Culture=neutral, PublicKeyToken=23c6f5d73be07eca, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelNumberFormat.1.0.10\lib\net20\ExcelNumberFormat.dll</HintPath>
+    </Reference>
     <Reference Include="KotOR_IO">
       <HintPath>..\..\KotOR_IO\KotOR_IO\bin\Debug\KotOR_IO.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -82,6 +92,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Digraph.cs" />
@@ -239,6 +250,7 @@
     <EmbeddedResource Include="Forms\PresetForm.resx">
       <DependentUpon>PresetForm.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/kotor Randomizer 2/packages.config
+++ b/kotor Randomizer 2/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ClosedXML" version="0.95.4" targetFramework="net452" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net452" />
+  <package id="ExcelNumberFormat" version="1.0.10" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
This pull request proposes fixes for both #7 and #18. Spoilers can now be generated for the Texture, Text, 2DA, and Other randomization categories. When the user tries to generate spoiler logs, a message box will display which logs were created, and will indicate when they weren't created. Unfortunately, there is not an ongoing indication that the log generation is in progress.

All spoiler logs will be combined into a single excel file (XLSX format) using a nuget package released under the MIT license. This package does not require excel to be installed to be able to create these files.