### PR TITLE
Party rando bug fix

### DIFF
--- a/kotor Randomizer 2/Randomization/OtherRando.cs
+++ b/kotor Randomizer 2/Randomization/OtherRando.cs
@@ -289,9 +289,40 @@ namespace kotor_Randomizer_2
                     // Add a Dummy Feat to prevent the feats menu from crashing.
                     (g.Top_Level.Fields.Where(x => x.Label == "FeatList").FirstOrDefault() as GFF.LIST).Structs.Add(new GFF.STRUCT("", 1, new List<GFF.FIELD>() {new GFF.WORD("Feat", 27) }));
 
+                    // If they are a Jedi class, add a Power to prevent powers menu from crashing.
+                    var charClassList = g.Top_Level.Fields.First(x => x.Label == "ClassList") as GFF.LIST;
+                    foreach (var classStruct in charClassList.Structs)
+                    {
+                        var charClassValue = (classStruct.Fields.First(x => x.Label == "Class") as GFF.INT).Value;
+                        if (charClassValue == 3 ||  // Jedi Guardian
+                            charClassValue == 4 ||  // Jedi Consular
+                            charClassValue == 5)    // Jedi Sentinel
+                        {
+                            // Build a power to add to the list.
+                            GFF.STRUCT affectMind = new GFF.STRUCT("", 3, new List<GFF.FIELD>()
+                            {
+                                new GFF.WORD("Spell", 6),
+                                new GFF.BYTE("SpellMetaMagic", 0),
+                                new GFF.BYTE("SpellFlags", 1),
+                            });
+
+                            if (!(classStruct.Fields.FirstOrDefault(x => x.Label == "KnownList0") is GFF.LIST knownList))
+                            {
+                                // KnownList0 doesn't exist. Create it and add Affect Mind.
+                                classStruct.Fields.Add(new GFF.LIST("KnownList0", new List<GFF.STRUCT>() { affectMind }));
+                            }
+                            else if (knownList.Structs.Count == 0)
+                            {
+                                // KnownList0 exists but is empty. Add affect Mind.
+                                knownList.Structs.Add(affectMind);
+                            }
+
+                            break;
+                        }
+                    }
+
                     g.WriteToFile(paths.Override + ID.Item2 + ".utc");
                 }
-
             }
 
             // Swoop Rando


### PR DESCRIPTION
Fixes #35.

- Skip UTC files that are invalid as party members.
  - UTC files without certain script fields were throwing exceptions.
  - Also skip chars with large or broken models.
- Expand the range of party member selection.
  - The reason for the previous max of 155 is unknown. The code now randomly selects any in the list of UTC files.
- Updated model exclusion checking code.
  - Used do...while loops to reduce code reuse.
  - Refactored broken and large model checking to make the logic easier to understand.