### PR TITLE
Settings update timing bug fix

### DIFF
--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -71,58 +71,58 @@
                 <value>False</value>
             </setting>
             <setting name="RandomizeArmor" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeStims" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeBelts" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeVarious" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeHides" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeArmbands" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeDroid" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeGloves" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeImplants" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeMask" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizePaz" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeMines" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeUpgrade" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeBlasters" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeCreature" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeLightsabers" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeGrenades" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeMelee" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeDoorModels" serializeAs="String">
                 <value>0</value>

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -134,46 +134,46 @@
                 <value>0</value>
             </setting>
             <setting name="TextureRandomizeCubeMaps" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeCreatures" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeEffects" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeItems" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizePlanetary" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeNPC" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizePlayHeads" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizePlayBodies" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizePlaceables" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeParty" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeStunt" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeVehicles" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeWeapons" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="TextureRandomizeOther" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="KotorIsRandomized" serializeAs="String">
                 <value>False</value>
@@ -203,7 +203,7 @@
                 <value>False</value>
             </setting>
             <setting name="TexturePack" serializeAs="String">
-                <value>0</value>
+                <value>HighQuality</value>
             </setting>
             <setting name="RandomizePazaakDecks" serializeAs="String">
                 <value>False</value>

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -20,22 +20,22 @@
                 <value>False</value>
             </setting>
             <setting name="RandomizeAreaMusic" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeAmbientNoise" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeCutsceneNoise" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeNpcSounds" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizePartySounds" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="RandomizeBattleMusic" serializeAs="String">
-                <value>0</value>
+                <value>None</value>
             </setting>
             <setting name="ModulesInitialized" serializeAs="String">
                 <value>False</value>
@@ -253,13 +253,13 @@
             <setting name="UseRandoRules" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="RemoveDmcaMusic" serializeAs="String">
-                <value>False</value>
-            </setting>
             <setting name="RandomizeSwoopBoosters" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="RandomizeSwoopObstacles" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="RemoveDmcaMusic" serializeAs="String">
                 <value>False</value>
             </setting>
         </kotor_Randomizer_2.Properties.Settings>

--- a/kotor Randomizer 2/Forms/ItemForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ItemForm.Designer.cs
@@ -393,6 +393,7 @@
             this.rbArmorSType.TabStop = true;
             this.rbArmorSType.Text = "Subtype";
             this.rbArmorSType.UseVisualStyleBackColor = true;
+            this.rbArmorSType.CheckedChanged += new System.EventHandler(this.rbArmorSType_CheckedChanged);
             // 
             // rbArmorType
             // 
@@ -403,6 +404,7 @@
             this.rbArmorType.TabIndex = 0;
             this.rbArmorType.Text = "Type";
             this.rbArmorType.UseVisualStyleBackColor = true;
+            this.rbArmorType.CheckedChanged += new System.EventHandler(this.rbArmorType_CheckedChanged);
             // 
             // rbArmorMax
             // 
@@ -415,6 +417,7 @@
             this.rbArmorMax.TabStop = true;
             this.rbArmorMax.Text = "Max";
             this.rbArmorMax.UseVisualStyleBackColor = true;
+            this.rbArmorMax.CheckedChanged += new System.EventHandler(this.rbArmorMax_CheckedChanged);
             // 
             // flpStims
             // 
@@ -442,6 +445,7 @@
             this.rbStimSType.TabStop = true;
             this.rbStimSType.Text = "Subtype";
             this.rbStimSType.UseVisualStyleBackColor = true;
+            this.rbStimSType.CheckedChanged += new System.EventHandler(this.rbStimSType_CheckedChanged);
             // 
             // rbStimulantType
             // 
@@ -452,6 +456,7 @@
             this.rbStimulantType.TabIndex = 0;
             this.rbStimulantType.Text = "Type";
             this.rbStimulantType.UseVisualStyleBackColor = true;
+            this.rbStimulantType.CheckedChanged += new System.EventHandler(this.rbStimulantType_CheckedChanged);
             // 
             // rbStimulantMax
             // 
@@ -464,6 +469,7 @@
             this.rbStimulantMax.TabStop = true;
             this.rbStimulantMax.Text = "Max";
             this.rbStimulantMax.UseVisualStyleBackColor = true;
+            this.rbStimulantMax.CheckedChanged += new System.EventHandler(this.rbStimulantMax_CheckedChanged);
             // 
             // flpBelts
             // 
@@ -500,6 +506,7 @@
             this.rbBeltType.TabIndex = 0;
             this.rbBeltType.Text = "Type";
             this.rbBeltType.UseVisualStyleBackColor = true;
+            this.rbBeltType.CheckedChanged += new System.EventHandler(this.rbBeltType_CheckedChanged);
             // 
             // rbBeltMax
             // 
@@ -512,6 +519,7 @@
             this.rbBeltMax.TabStop = true;
             this.rbBeltMax.Text = "Max";
             this.rbBeltMax.UseVisualStyleBackColor = true;
+            this.rbBeltMax.CheckedChanged += new System.EventHandler(this.rbBeltMax_CheckedChanged);
             // 
             // flpVarious
             // 
@@ -548,6 +556,7 @@
             this.rbVariousType.TabIndex = 0;
             this.rbVariousType.Text = "Type";
             this.rbVariousType.UseVisualStyleBackColor = true;
+            this.rbVariousType.CheckedChanged += new System.EventHandler(this.rbVariousType_CheckedChanged);
             // 
             // rbVariousMax
             // 
@@ -560,6 +569,7 @@
             this.rbVariousMax.TabStop = true;
             this.rbVariousMax.Text = "Max";
             this.rbVariousMax.UseVisualStyleBackColor = true;
+            this.rbVariousMax.CheckedChanged += new System.EventHandler(this.rbVariousMax_CheckedChanged);
             // 
             // flpDroid
             // 
@@ -587,6 +597,7 @@
             this.rbDroidSType.TabStop = true;
             this.rbDroidSType.Text = "Subtype";
             this.rbDroidSType.UseVisualStyleBackColor = true;
+            this.rbDroidSType.CheckedChanged += new System.EventHandler(this.rbDroidSType_CheckedChanged);
             // 
             // rbDroidType
             // 
@@ -597,6 +608,7 @@
             this.rbDroidType.TabIndex = 0;
             this.rbDroidType.Text = "Type";
             this.rbDroidType.UseVisualStyleBackColor = true;
+            this.rbDroidType.CheckedChanged += new System.EventHandler(this.rbDroidType_CheckedChanged);
             // 
             // rbDroidMax
             // 
@@ -609,6 +621,7 @@
             this.rbDroidMax.TabStop = true;
             this.rbDroidMax.Text = "Max";
             this.rbDroidMax.UseVisualStyleBackColor = true;
+            this.rbDroidMax.CheckedChanged += new System.EventHandler(this.rbDroidMax_CheckedChanged);
             // 
             // flpArmbands
             // 
@@ -636,6 +649,7 @@
             this.rbArmbandSType.TabStop = true;
             this.rbArmbandSType.Text = "Subtype";
             this.rbArmbandSType.UseVisualStyleBackColor = true;
+            this.rbArmbandSType.CheckedChanged += new System.EventHandler(this.rbArmbandSType_CheckedChanged);
             // 
             // rbArmbandType
             // 
@@ -648,6 +662,7 @@
             this.rbArmbandType.TabStop = true;
             this.rbArmbandType.Text = "Type";
             this.rbArmbandType.UseVisualStyleBackColor = true;
+            this.rbArmbandType.CheckedChanged += new System.EventHandler(this.rbArmbandType_CheckedChanged);
             // 
             // rbArmbandMax
             // 
@@ -658,6 +673,7 @@
             this.rbArmbandMax.TabIndex = 1;
             this.rbArmbandMax.Text = "Max";
             this.rbArmbandMax.UseVisualStyleBackColor = true;
+            this.rbArmbandMax.CheckedChanged += new System.EventHandler(this.rbArmbandMax_CheckedChanged);
             // 
             // flpGloves
             // 
@@ -694,6 +710,7 @@
             this.rbGloveType.TabIndex = 0;
             this.rbGloveType.Text = "Type";
             this.rbGloveType.UseVisualStyleBackColor = true;
+            this.rbGloveType.CheckedChanged += new System.EventHandler(this.rbGloveType_CheckedChanged);
             // 
             // rbGloveMax
             // 
@@ -706,6 +723,7 @@
             this.rbGloveMax.TabStop = true;
             this.rbGloveMax.Text = "Max";
             this.rbGloveMax.UseVisualStyleBackColor = true;
+            this.rbGloveMax.CheckedChanged += new System.EventHandler(this.rbGloveMax_CheckedChanged);
             // 
             // flpImplants
             // 
@@ -733,6 +751,7 @@
             this.rbImplantSType.TabStop = true;
             this.rbImplantSType.Text = "Subtype";
             this.rbImplantSType.UseVisualStyleBackColor = true;
+            this.rbImplantSType.CheckedChanged += new System.EventHandler(this.rbImplantSType_CheckedChanged);
             // 
             // rbImplantType
             // 
@@ -743,6 +762,7 @@
             this.rbImplantType.TabIndex = 0;
             this.rbImplantType.Text = "Type";
             this.rbImplantType.UseVisualStyleBackColor = true;
+            this.rbImplantType.CheckedChanged += new System.EventHandler(this.rbImplantType_CheckedChanged);
             // 
             // rbImplantMax
             // 
@@ -755,6 +775,7 @@
             this.rbImplantMax.TabStop = true;
             this.rbImplantMax.Text = "Max";
             this.rbImplantMax.UseVisualStyleBackColor = true;
+            this.rbImplantMax.CheckedChanged += new System.EventHandler(this.rbImplantMax_CheckedChanged);
             // 
             // flpMasks
             // 
@@ -782,6 +803,7 @@
             this.rbMaskSType.TabStop = true;
             this.rbMaskSType.Text = "Subtype";
             this.rbMaskSType.UseVisualStyleBackColor = true;
+            this.rbMaskSType.CheckedChanged += new System.EventHandler(this.rbMaskSType_CheckedChanged);
             // 
             // rbMaskType
             // 
@@ -792,6 +814,7 @@
             this.rbMaskType.TabIndex = 0;
             this.rbMaskType.Text = "Type";
             this.rbMaskType.UseVisualStyleBackColor = true;
+            this.rbMaskType.CheckedChanged += new System.EventHandler(this.rbMaskType_CheckedChanged);
             // 
             // rbMaskMax
             // 
@@ -804,6 +827,7 @@
             this.rbMaskMax.TabStop = true;
             this.rbMaskMax.Text = "Max";
             this.rbMaskMax.UseVisualStyleBackColor = true;
+            this.rbMaskMax.CheckedChanged += new System.EventHandler(this.rbMaskMax_CheckedChanged);
             // 
             // flpPaz
             // 
@@ -840,6 +864,7 @@
             this.rbPazaakType.TabIndex = 0;
             this.rbPazaakType.Text = "Type";
             this.rbPazaakType.UseVisualStyleBackColor = true;
+            this.rbPazaakType.CheckedChanged += new System.EventHandler(this.rbPazaakType_CheckedChanged);
             // 
             // rbPazaakMax
             // 
@@ -852,6 +877,7 @@
             this.rbPazaakMax.TabStop = true;
             this.rbPazaakMax.Text = "Max";
             this.rbPazaakMax.UseVisualStyleBackColor = true;
+            this.rbPazaakMax.CheckedChanged += new System.EventHandler(this.rbPazaakMax_CheckedChanged);
             // 
             // flpMines
             // 
@@ -879,6 +905,7 @@
             this.rbMineSType.TabStop = true;
             this.rbMineSType.Text = "Subtype";
             this.rbMineSType.UseVisualStyleBackColor = true;
+            this.rbMineSType.CheckedChanged += new System.EventHandler(this.rbMineSType_CheckedChanged);
             // 
             // rbMineType
             // 
@@ -889,6 +916,7 @@
             this.rbMineType.TabIndex = 0;
             this.rbMineType.Text = "Type";
             this.rbMineType.UseVisualStyleBackColor = true;
+            this.rbMineType.CheckedChanged += new System.EventHandler(this.rbMineType_CheckedChanged);
             // 
             // rbMineMax
             // 
@@ -901,6 +929,7 @@
             this.rbMineMax.TabStop = true;
             this.rbMineMax.Text = "Max";
             this.rbMineMax.UseVisualStyleBackColor = true;
+            this.rbMineMax.CheckedChanged += new System.EventHandler(this.rbMineMax_CheckedChanged);
             // 
             // flpUpgrades
             // 
@@ -928,6 +957,7 @@
             this.rbUpgradeSType.TabStop = true;
             this.rbUpgradeSType.Text = "Subtype";
             this.rbUpgradeSType.UseVisualStyleBackColor = true;
+            this.rbUpgradeSType.CheckedChanged += new System.EventHandler(this.rbUpgradeSType_CheckedChanged);
             // 
             // rbUpgradeType
             // 
@@ -938,6 +968,7 @@
             this.rbUpgradeType.TabIndex = 0;
             this.rbUpgradeType.Text = "Type";
             this.rbUpgradeType.UseVisualStyleBackColor = true;
+            this.rbUpgradeType.CheckedChanged += new System.EventHandler(this.rbUpgradeType_CheckedChanged);
             // 
             // rbUpgradeMax
             // 
@@ -950,6 +981,7 @@
             this.rbUpgradeMax.TabStop = true;
             this.rbUpgradeMax.Text = "Max";
             this.rbUpgradeMax.UseVisualStyleBackColor = true;
+            this.rbUpgradeMax.CheckedChanged += new System.EventHandler(this.rbUpgradeMax_CheckedChanged);
             // 
             // flpBlasters
             // 
@@ -977,6 +1009,7 @@
             this.rbBlasterSType.TabStop = true;
             this.rbBlasterSType.Text = "Subtype";
             this.rbBlasterSType.UseVisualStyleBackColor = true;
+            this.rbBlasterSType.CheckedChanged += new System.EventHandler(this.rbBlasterSType_CheckedChanged);
             // 
             // rbBlasterType
             // 
@@ -987,6 +1020,7 @@
             this.rbBlasterType.TabIndex = 0;
             this.rbBlasterType.Text = "Type";
             this.rbBlasterType.UseVisualStyleBackColor = true;
+            this.rbBlasterType.CheckedChanged += new System.EventHandler(this.rbBlasterType_CheckedChanged);
             // 
             // rbBlasterMax
             // 
@@ -999,6 +1033,7 @@
             this.rbBlasterMax.TabStop = true;
             this.rbBlasterMax.Text = "Max";
             this.rbBlasterMax.UseVisualStyleBackColor = true;
+            this.rbBlasterMax.CheckedChanged += new System.EventHandler(this.rbBlasterMax_CheckedChanged);
             // 
             // flpCreature
             // 
@@ -1026,6 +1061,7 @@
             this.rbCreatureWeaponSType.TabStop = true;
             this.rbCreatureWeaponSType.Text = "Subtype";
             this.rbCreatureWeaponSType.UseVisualStyleBackColor = true;
+            this.rbCreatureWeaponSType.CheckedChanged += new System.EventHandler(this.rbCreatureWeaponSType_CheckedChanged);
             // 
             // rbCreatureWeaponType
             // 
@@ -1036,6 +1072,7 @@
             this.rbCreatureWeaponType.TabIndex = 0;
             this.rbCreatureWeaponType.Text = "Type";
             this.rbCreatureWeaponType.UseVisualStyleBackColor = true;
+            this.rbCreatureWeaponType.CheckedChanged += new System.EventHandler(this.rbCreatureWeaponType_CheckedChanged);
             // 
             // rbCreatureWeaponMax
             // 
@@ -1048,6 +1085,7 @@
             this.rbCreatureWeaponMax.TabStop = true;
             this.rbCreatureWeaponMax.Text = "Max";
             this.rbCreatureWeaponMax.UseVisualStyleBackColor = true;
+            this.rbCreatureWeaponMax.CheckedChanged += new System.EventHandler(this.rbCreatureWeaponMax_CheckedChanged);
             // 
             // flpLightsabers
             // 
@@ -1075,6 +1113,7 @@
             this.rbLightsaberSType.TabStop = true;
             this.rbLightsaberSType.Text = "Subtype";
             this.rbLightsaberSType.UseVisualStyleBackColor = true;
+            this.rbLightsaberSType.CheckedChanged += new System.EventHandler(this.rbLightsaberSType_CheckedChanged);
             // 
             // rbLightsaberType
             // 
@@ -1085,6 +1124,7 @@
             this.rbLightsaberType.TabIndex = 0;
             this.rbLightsaberType.Text = "Type";
             this.rbLightsaberType.UseVisualStyleBackColor = true;
+            this.rbLightsaberType.CheckedChanged += new System.EventHandler(this.rbLightsaberType_CheckedChanged);
             // 
             // rbLightsaberMax
             // 
@@ -1097,6 +1137,7 @@
             this.rbLightsaberMax.TabStop = true;
             this.rbLightsaberMax.Text = "Max";
             this.rbLightsaberMax.UseVisualStyleBackColor = true;
+            this.rbLightsaberMax.CheckedChanged += new System.EventHandler(this.rbLightsaberMax_CheckedChanged);
             // 
             // flpGrenades
             // 
@@ -1133,6 +1174,7 @@
             this.rbGrenadeType.TabIndex = 0;
             this.rbGrenadeType.Text = "Type";
             this.rbGrenadeType.UseVisualStyleBackColor = true;
+            this.rbGrenadeType.CheckedChanged += new System.EventHandler(this.rbGrenadeType_CheckedChanged);
             // 
             // rbGrenadeMax
             // 
@@ -1145,6 +1187,7 @@
             this.rbGrenadeMax.TabStop = true;
             this.rbGrenadeMax.Text = "Max";
             this.rbGrenadeMax.UseVisualStyleBackColor = true;
+            this.rbGrenadeMax.CheckedChanged += new System.EventHandler(this.rbGrenadeMax_CheckedChanged);
             // 
             // flpMelee
             // 
@@ -1172,6 +1215,7 @@
             this.rbMeleeSType.TabStop = true;
             this.rbMeleeSType.Text = "Subtype";
             this.rbMeleeSType.UseVisualStyleBackColor = true;
+            this.rbMeleeSType.CheckedChanged += new System.EventHandler(this.rbMeleeSType_CheckedChanged);
             // 
             // rbMeleeType
             // 
@@ -1182,6 +1226,7 @@
             this.rbMeleeType.TabIndex = 0;
             this.rbMeleeType.Text = "Type";
             this.rbMeleeType.UseVisualStyleBackColor = true;
+            this.rbMeleeType.CheckedChanged += new System.EventHandler(this.rbMeleeType_CheckedChanged);
             // 
             // rbMeleeMax
             // 
@@ -1194,6 +1239,7 @@
             this.rbMeleeMax.TabStop = true;
             this.rbMeleeMax.Text = "Max";
             this.rbMeleeMax.UseVisualStyleBackColor = true;
+            this.rbMeleeMax.CheckedChanged += new System.EventHandler(this.rbMeleeMax_CheckedChanged);
             // 
             // cbCreatureHide
             // 
@@ -1243,6 +1289,7 @@
             this.rbCreatureHideType.TabIndex = 0;
             this.rbCreatureHideType.Text = "Type";
             this.rbCreatureHideType.UseVisualStyleBackColor = true;
+            this.rbCreatureHideType.CheckedChanged += new System.EventHandler(this.rbCreatureHideType_CheckedChanged);
             // 
             // rbCreatureHideMax
             // 
@@ -1255,6 +1302,7 @@
             this.rbCreatureHideMax.TabStop = true;
             this.rbCreatureHideMax.Text = "Max";
             this.rbCreatureHideMax.UseVisualStyleBackColor = true;
+            this.rbCreatureHideMax.CheckedChanged += new System.EventHandler(this.rbCreatureHideMax_CheckedChanged);
             // 
             // lblOmitted
             // 

--- a/kotor Randomizer 2/Forms/ItemForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ItemForm.Designer.cs
@@ -126,6 +126,8 @@
             this.bSubtypeAll = new System.Windows.Forms.Button();
             this.bTypeAll = new System.Windows.Forms.Button();
             this.bMaxAll = new System.Windows.Forms.Button();
+            this.bResetOmittedItems = new System.Windows.Forms.Button();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.flpArmor.SuspendLayout();
             this.flpStims.SuspendLayout();
             this.flpBelts.SuspendLayout();
@@ -379,7 +381,7 @@
             this.flpArmor.Location = new System.Drawing.Point(150, 81);
             this.flpArmor.Name = "flpArmor";
             this.flpArmor.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpArmor.Size = new System.Drawing.Size(180, 24);
+            this.flpArmor.Size = new System.Drawing.Size(183, 24);
             this.flpArmor.TabIndex = 17;
             // 
             // rbArmorSType
@@ -431,7 +433,7 @@
             this.flpStims.Location = new System.Drawing.Point(150, 501);
             this.flpStims.Name = "flpStims";
             this.flpStims.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpStims.Size = new System.Drawing.Size(180, 24);
+            this.flpStims.Size = new System.Drawing.Size(183, 24);
             this.flpStims.TabIndex = 18;
             // 
             // rbStimSType
@@ -483,7 +485,7 @@
             this.flpBelts.Location = new System.Drawing.Point(150, 111);
             this.flpBelts.Name = "flpBelts";
             this.flpBelts.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpBelts.Size = new System.Drawing.Size(180, 24);
+            this.flpBelts.Size = new System.Drawing.Size(183, 24);
             this.flpBelts.TabIndex = 18;
             // 
             // labelSpacer1
@@ -533,7 +535,7 @@
             this.flpVarious.Location = new System.Drawing.Point(150, 561);
             this.flpVarious.Name = "flpVarious";
             this.flpVarious.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpVarious.Size = new System.Drawing.Size(180, 24);
+            this.flpVarious.Size = new System.Drawing.Size(183, 24);
             this.flpVarious.TabIndex = 18;
             // 
             // labelSpacer6
@@ -583,7 +585,7 @@
             this.flpDroid.Location = new System.Drawing.Point(150, 231);
             this.flpDroid.Name = "flpDroid";
             this.flpDroid.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpDroid.Size = new System.Drawing.Size(180, 24);
+            this.flpDroid.Size = new System.Drawing.Size(183, 24);
             this.flpDroid.TabIndex = 18;
             // 
             // rbDroidSType
@@ -635,7 +637,7 @@
             this.flpArmbands.Location = new System.Drawing.Point(150, 51);
             this.flpArmbands.Name = "flpArmbands";
             this.flpArmbands.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpArmbands.Size = new System.Drawing.Size(180, 24);
+            this.flpArmbands.Size = new System.Drawing.Size(183, 24);
             this.flpArmbands.TabIndex = 18;
             // 
             // rbArmbandSType
@@ -687,7 +689,7 @@
             this.flpGloves.Location = new System.Drawing.Point(150, 261);
             this.flpGloves.Name = "flpGloves";
             this.flpGloves.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpGloves.Size = new System.Drawing.Size(180, 24);
+            this.flpGloves.Size = new System.Drawing.Size(183, 24);
             this.flpGloves.TabIndex = 18;
             // 
             // labelSpacer3
@@ -737,7 +739,7 @@
             this.flpImplants.Location = new System.Drawing.Point(150, 321);
             this.flpImplants.Name = "flpImplants";
             this.flpImplants.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpImplants.Size = new System.Drawing.Size(180, 24);
+            this.flpImplants.Size = new System.Drawing.Size(183, 24);
             this.flpImplants.TabIndex = 18;
             // 
             // rbImplantSType
@@ -789,7 +791,7 @@
             this.flpMasks.Location = new System.Drawing.Point(150, 381);
             this.flpMasks.Name = "flpMasks";
             this.flpMasks.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpMasks.Size = new System.Drawing.Size(180, 24);
+            this.flpMasks.Size = new System.Drawing.Size(183, 24);
             this.flpMasks.TabIndex = 18;
             // 
             // rbMaskSType
@@ -841,7 +843,7 @@
             this.flpPaz.Location = new System.Drawing.Point(150, 471);
             this.flpPaz.Name = "flpPaz";
             this.flpPaz.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpPaz.Size = new System.Drawing.Size(180, 24);
+            this.flpPaz.Size = new System.Drawing.Size(183, 24);
             this.flpPaz.TabIndex = 18;
             // 
             // labelSpacer5
@@ -891,7 +893,7 @@
             this.flpMines.Location = new System.Drawing.Point(150, 441);
             this.flpMines.Name = "flpMines";
             this.flpMines.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpMines.Size = new System.Drawing.Size(180, 24);
+            this.flpMines.Size = new System.Drawing.Size(183, 24);
             this.flpMines.TabIndex = 18;
             // 
             // rbMineSType
@@ -943,7 +945,7 @@
             this.flpUpgrades.Location = new System.Drawing.Point(150, 531);
             this.flpUpgrades.Name = "flpUpgrades";
             this.flpUpgrades.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpUpgrades.Size = new System.Drawing.Size(180, 24);
+            this.flpUpgrades.Size = new System.Drawing.Size(183, 24);
             this.flpUpgrades.TabIndex = 18;
             // 
             // rbUpgradeSType
@@ -995,7 +997,7 @@
             this.flpBlasters.Location = new System.Drawing.Point(150, 141);
             this.flpBlasters.Name = "flpBlasters";
             this.flpBlasters.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpBlasters.Size = new System.Drawing.Size(180, 24);
+            this.flpBlasters.Size = new System.Drawing.Size(183, 24);
             this.flpBlasters.TabIndex = 18;
             // 
             // rbBlasterSType
@@ -1047,7 +1049,7 @@
             this.flpCreature.Location = new System.Drawing.Point(150, 201);
             this.flpCreature.Name = "flpCreature";
             this.flpCreature.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpCreature.Size = new System.Drawing.Size(180, 24);
+            this.flpCreature.Size = new System.Drawing.Size(183, 24);
             this.flpCreature.TabIndex = 18;
             // 
             // rbCreatureWeaponSType
@@ -1099,7 +1101,7 @@
             this.flpLightsabers.Location = new System.Drawing.Point(150, 351);
             this.flpLightsabers.Name = "flpLightsabers";
             this.flpLightsabers.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpLightsabers.Size = new System.Drawing.Size(180, 24);
+            this.flpLightsabers.Size = new System.Drawing.Size(183, 24);
             this.flpLightsabers.TabIndex = 18;
             // 
             // rbLightsaberSType
@@ -1151,7 +1153,7 @@
             this.flpGrenades.Location = new System.Drawing.Point(150, 291);
             this.flpGrenades.Name = "flpGrenades";
             this.flpGrenades.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpGrenades.Size = new System.Drawing.Size(180, 24);
+            this.flpGrenades.Size = new System.Drawing.Size(183, 24);
             this.flpGrenades.TabIndex = 18;
             // 
             // labelSpacer4
@@ -1201,7 +1203,7 @@
             this.flpMelee.Location = new System.Drawing.Point(150, 411);
             this.flpMelee.Name = "flpMelee";
             this.flpMelee.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpMelee.Size = new System.Drawing.Size(180, 24);
+            this.flpMelee.Size = new System.Drawing.Size(183, 24);
             this.flpMelee.TabIndex = 18;
             // 
             // rbMeleeSType
@@ -1266,7 +1268,7 @@
             this.flpHides.Location = new System.Drawing.Point(150, 171);
             this.flpHides.Name = "flpHides";
             this.flpHides.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
-            this.flpHides.Size = new System.Drawing.Size(180, 24);
+            this.flpHides.Size = new System.Drawing.Size(183, 24);
             this.flpHides.TabIndex = 19;
             // 
             // labelSpacer2
@@ -1308,11 +1310,11 @@
             // 
             this.lblOmitted.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblOmitted.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblOmitted.Location = new System.Drawing.Point(340, 17);
+            this.lblOmitted.Location = new System.Drawing.Point(349, 17);
             this.lblOmitted.Name = "lblOmitted";
-            this.lblOmitted.Size = new System.Drawing.Size(200, 20);
+            this.lblOmitted.Size = new System.Drawing.Size(140, 20);
             this.lblOmitted.TabIndex = 24;
-            this.lblOmitted.Text = "Omitted";
+            this.lblOmitted.Text = "Omitted Items";
             this.lblOmitted.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lbOmitItems
@@ -1321,7 +1323,7 @@
             this.lbOmitItems.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.lbOmitItems.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.lbOmitItems.FormattingEnabled = true;
-            this.lbOmitItems.Location = new System.Drawing.Point(340, 45);
+            this.lbOmitItems.Location = new System.Drawing.Point(349, 45);
             this.lbOmitItems.Name = "lbOmitItems";
             this.lbOmitItems.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
             this.lbOmitItems.Size = new System.Drawing.Size(200, 509);
@@ -1334,12 +1336,14 @@
             this.tbItemOmitAdd.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.tbItemOmitAdd.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.tbItemOmitAdd.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.tbItemOmitAdd.CharacterCasing = System.Windows.Forms.CharacterCasing.Lower;
             this.tbItemOmitAdd.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.tbItemOmitAdd.Location = new System.Drawing.Point(340, 564);
+            this.tbItemOmitAdd.Location = new System.Drawing.Point(349, 564);
+            this.tbItemOmitAdd.MaxLength = 50;
             this.tbItemOmitAdd.Name = "tbItemOmitAdd";
             this.tbItemOmitAdd.Size = new System.Drawing.Size(140, 20);
             this.tbItemOmitAdd.TabIndex = 26;
-            this.tbItemOmitAdd.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbItemOmitAdd_KeyPress);
+            this.tbItemOmitAdd.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tbItemOmitAdd_KeyUp);
             // 
             // bAddOmitItem
             // 
@@ -1351,7 +1355,7 @@
             this.bAddOmitItem.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.bAddOmitItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.bAddOmitItem.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.bAddOmitItem.Location = new System.Drawing.Point(490, 564);
+            this.bAddOmitItem.Location = new System.Drawing.Point(499, 564);
             this.bAddOmitItem.Name = "bAddOmitItem";
             this.bAddOmitItem.Size = new System.Drawing.Size(50, 20);
             this.bAddOmitItem.TabIndex = 27;
@@ -1407,12 +1411,34 @@
             this.bMaxAll.UseVisualStyleBackColor = false;
             this.bMaxAll.Click += new System.EventHandler(this.bMaxAll_Click);
             // 
+            // bResetOmittedItems
+            // 
+            this.bResetOmittedItems.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.bResetOmittedItems.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
+            this.bResetOmittedItems.Location = new System.Drawing.Point(496, 17);
+            this.bResetOmittedItems.Name = "bResetOmittedItems";
+            this.bResetOmittedItems.Size = new System.Drawing.Size(53, 23);
+            this.bResetOmittedItems.TabIndex = 34;
+            this.bResetOmittedItems.Text = "Reset";
+            this.bResetOmittedItems.UseVisualStyleBackColor = false;
+            this.bResetOmittedItems.Click += new System.EventHandler(this.bResetOmittedItems_Click);
+            // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.panel1.Location = new System.Drawing.Point(338, 17);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(2, 567);
+            this.panel1.TabIndex = 35;
+            // 
             // ItemForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(561, 599);
+            this.ClientSize = new System.Drawing.Size(564, 599);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.bResetOmittedItems);
             this.Controls.Add(this.bMaxAll);
             this.Controls.Add(this.bTypeAll);
             this.Controls.Add(this.bSubtypeAll);
@@ -1607,5 +1633,7 @@
         private System.Windows.Forms.Button bSubtypeAll;
         private System.Windows.Forms.Button bTypeAll;
         private System.Windows.Forms.Button bMaxAll;
+        private System.Windows.Forms.Button bResetOmittedItems;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/kotor Randomizer 2/Forms/ItemForm.cs
+++ b/kotor Randomizer 2/Forms/ItemForm.cs
@@ -14,24 +14,24 @@ namespace kotor_Randomizer_2
             lbOmitItems.DataSource = Globals.OmitItems;
 
             //Set Intiial Values
-            RandomizeArmbands = (RandomizationLevel)Properties.Settings.Default.RandomizeArmbands;
-            RandomizeArmor = (RandomizationLevel)Properties.Settings.Default.RandomizeArmor;
-            RandomizeBelts = (RandomizationLevel)Properties.Settings.Default.RandomizeBelts;
-            RandomizeBlasters = (RandomizationLevel)Properties.Settings.Default.RandomizeBlasters;
-            RandomizeHides = (RandomizationLevel)Properties.Settings.Default.RandomizeHides;
-            RandomizeCreature = (RandomizationLevel)Properties.Settings.Default.RandomizeCreature;
-            RandomizeDroid = (RandomizationLevel)Properties.Settings.Default.RandomizeDroid;
-            RandomizeGloves = (RandomizationLevel)Properties.Settings.Default.RandomizeGloves;
-            RandomizeGrenades = (RandomizationLevel)Properties.Settings.Default.RandomizeGrenades;
-            RandomizeImplants = (RandomizationLevel)Properties.Settings.Default.RandomizeImplants;
-            RandomizeLightsabers = (RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers;
-            RandomizeMask = (RandomizationLevel)Properties.Settings.Default.RandomizeMask;
-            RandomizeMelee = (RandomizationLevel)Properties.Settings.Default.RandomizeMelee;
-            RandomizeMines = (RandomizationLevel)Properties.Settings.Default.RandomizeMines;
-            RandomizePaz = (RandomizationLevel)Properties.Settings.Default.RandomizePaz;
-            RandomizeStims = (RandomizationLevel)Properties.Settings.Default.RandomizeStims;
-            RandomizeUpgrade = (RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade;
-            RandomizeVarious = (RandomizationLevel)Properties.Settings.Default.RandomizeVarious;
+            RandomizeArmbands = Properties.Settings.Default.RandomizeArmbands;
+            RandomizeArmor = Properties.Settings.Default.RandomizeArmor;
+            RandomizeBelts = Properties.Settings.Default.RandomizeBelts;
+            RandomizeBlasters = Properties.Settings.Default.RandomizeBlasters;
+            RandomizeHides = Properties.Settings.Default.RandomizeHides;
+            RandomizeCreature = Properties.Settings.Default.RandomizeCreature;
+            RandomizeDroid = Properties.Settings.Default.RandomizeDroid;
+            RandomizeGloves = Properties.Settings.Default.RandomizeGloves;
+            RandomizeGrenades = Properties.Settings.Default.RandomizeGrenades;
+            RandomizeImplants = Properties.Settings.Default.RandomizeImplants;
+            RandomizeLightsabers = Properties.Settings.Default.RandomizeLightsabers;
+            RandomizeMask = Properties.Settings.Default.RandomizeMask;
+            RandomizeMelee = Properties.Settings.Default.RandomizeMelee;
+            RandomizeMines = Properties.Settings.Default.RandomizeMines;
+            RandomizePaz = Properties.Settings.Default.RandomizePaz;
+            RandomizeStims = Properties.Settings.Default.RandomizeStims;
+            RandomizeUpgrade = Properties.Settings.Default.RandomizeUpgrade;
+            RandomizeVarious = Properties.Settings.Default.RandomizeVarious;
 
             // Create easy access lists.
             CheckBoxes.AddRange(new List<CheckBox>()
@@ -1029,15 +1029,32 @@ namespace kotor_Randomizer_2
         }
 
         // Omitted item handlers
-        private void bAddOmitItem_Click(object sender, EventArgs e)
+        private void bResetOmittedItems_Click(object sender, EventArgs e)
         {
-            Globals.OmitItems.Add(tbItemOmitAdd.Text);
-            lbOmitItems.DataSource = Globals.OmitItems;
+            Globals.OmitItems.Clear();
+            foreach (var item in Globals.DEFAULT_OMIT_ITEMS)
+            {
+                Globals.OmitItems.Add(item);
+            }
+            System.Media.SystemSounds.Exclamation.Play();
         }
 
-        private void tbItemOmitAdd_KeyPress(object sender, KeyPressEventArgs e)
+        private void bAddOmitItem_Click(object sender, EventArgs e)
         {
-            if (e.KeyChar == (char)Keys.Enter)
+            if (string.IsNullOrWhiteSpace(tbItemOmitAdd.Text) || Globals.OmitItems.Contains(tbItemOmitAdd.Text))
+            {
+                System.Media.SystemSounds.Asterisk.Play();
+            }
+            else
+            {
+                Globals.OmitItems.Add(tbItemOmitAdd.Text);
+            }
+            tbItemOmitAdd.Text = string.Empty;
+        }
+
+        private void tbItemOmitAdd_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
             {
                 bAddOmitItem_Click(sender, e);
             }
@@ -1055,7 +1072,6 @@ namespace kotor_Randomizer_2
             {
                 Globals.OmitItems.Remove(s);
             }
-            lbOmitItems.DataSource = Globals.OmitItems;
         }
 
         private void lbOmitItems_KeyPress(object sender, KeyPressEventArgs e)

--- a/kotor Randomizer 2/Forms/ItemForm.cs
+++ b/kotor Randomizer 2/Forms/ItemForm.cs
@@ -903,128 +903,132 @@ namespace kotor_Randomizer_2
         private List<RadioButton> TypeRadioButtons = new List<RadioButton>();
         private List<RadioButton> MaxRadioButtons = new List<RadioButton>();
 
-        //Check boxes Mostly
+        // Checkbox handlers
+        private void cbArmbands_CheckedChanged(object sender, EventArgs e)
+        {
+            flpArmbands.Enabled = cbArmband.Checked;
+            Properties.Settings.Default.RandomizeArmbands = RandomizeArmbands;
+        }
+
         private void cbArmor_CheckedChanged(object sender, EventArgs e)
         {
             flpArmor.Enabled = cbArmor.Checked;
-        }
-
-        private void cbStims_CheckedChanged(object sender, EventArgs e)
-        {
-            flpStims.Enabled = cbStimulant.Checked;
+            Properties.Settings.Default.RandomizeArmor = RandomizeArmor;
         }
 
         private void cbBelts_CheckedChanged(object sender, EventArgs e)
         {
             flpBelts.Enabled = cbBelt.Checked;
-        }
-
-        private void cbVarious_CheckedChanged(object sender, EventArgs e)
-        {
-            flpVarious.Enabled = cbVarious.Checked;
-        }
-
-        private void cbHides_CheckedChanged(object sender, EventArgs e)
-        {
-            flpHides.Enabled = cbCreatureHide.Checked;
-        }
-
-        private void cbDroid_CheckedChanged(object sender, EventArgs e)
-        {
-            flpDroid.Enabled = cbDroid.Checked;
-        }
-
-        private void cbArmbands_CheckedChanged(object sender, EventArgs e)
-        {
-            flpArmbands.Enabled = cbArmband.Checked;
-        }
-
-        private void cbGloves_CheckedChanged(object sender, EventArgs e)
-        {
-            flpGloves.Enabled = cbGlove.Checked;
-        }
-
-        private void cbImplants_CheckedChanged(object sender, EventArgs e)
-        {
-            flpImplants.Enabled = cbImplant.Checked;
-        }
-
-        private void cbMask_CheckedChanged(object sender, EventArgs e)
-        {
-            flpMasks.Enabled = cbMask.Checked;
-        }
-
-        private void cbPaz_CheckedChanged(object sender, EventArgs e)
-        {
-            flpPaz.Enabled = cbPazaak.Checked;
-        }
-
-        private void cbMines_CheckedChanged(object sender, EventArgs e)
-        {
-            flpMines.Enabled = cbMine.Checked;
-        }
-
-        private void cbUpgrade_CheckedChanged(object sender, EventArgs e)
-        {
-            flpUpgrades.Enabled = cbUpgrade.Checked;
+            Properties.Settings.Default.RandomizeBelts = RandomizeBelts;
         }
 
         private void cbBlasters_CheckedChanged(object sender, EventArgs e)
         {
             flpBlasters.Enabled = cbBlaster.Checked;
+            Properties.Settings.Default.RandomizeBlasters = RandomizeBlasters;
         }
 
         private void cbCreature_CheckedChanged(object sender, EventArgs e)
         {
             flpCreature.Enabled = cbCreatureWeapon.Checked;
+            Properties.Settings.Default.RandomizeCreature = RandomizeCreature;
         }
 
-        private void cbLightsabers_CheckedChanged(object sender, EventArgs e)
+        private void cbDroid_CheckedChanged(object sender, EventArgs e)
         {
-            flpLightsabers.Enabled = cbLightsaber.Checked;
+            flpDroid.Enabled = cbDroid.Checked;
+            Properties.Settings.Default.RandomizeDroid = RandomizeDroid;
+        }
+
+        private void cbGloves_CheckedChanged(object sender, EventArgs e)
+        {
+            flpGloves.Enabled = cbGlove.Checked;
+            Properties.Settings.Default.RandomizeGloves = RandomizeGloves;
         }
 
         private void cbGrenades_CheckedChanged(object sender, EventArgs e)
         {
             flpGrenades.Enabled = cbGrenade.Checked;
+            Properties.Settings.Default.RandomizeGrenades = RandomizeGrenades;
+        }
+
+        private void cbHides_CheckedChanged(object sender, EventArgs e)
+        {
+            flpHides.Enabled = cbCreatureHide.Checked;
+            Properties.Settings.Default.RandomizeHides = RandomizeHides;
+        }
+
+        private void cbImplants_CheckedChanged(object sender, EventArgs e)
+        {
+            flpImplants.Enabled = cbImplant.Checked;
+            Properties.Settings.Default.RandomizeImplants = RandomizeImplants;
+        }
+
+        private void cbLightsabers_CheckedChanged(object sender, EventArgs e)
+        {
+            flpLightsabers.Enabled = cbLightsaber.Checked;
+            Properties.Settings.Default.RandomizeLightsabers = RandomizeLightsabers;
+        }
+
+        private void cbMask_CheckedChanged(object sender, EventArgs e)
+        {
+            flpMasks.Enabled = cbMask.Checked;
+            Properties.Settings.Default.RandomizeMask = RandomizeMask;
         }
 
         private void cbMelee_CheckedChanged(object sender, EventArgs e)
         {
             flpMelee.Enabled = cbMelee.Checked;
+            Properties.Settings.Default.RandomizeMelee = RandomizeMelee;
         }
 
-        //Save appdata on form close. (Now that I think about it, we only really need to save this once when the program closes.... oh well)
+        private void cbMines_CheckedChanged(object sender, EventArgs e)
+        {
+            flpMines.Enabled = cbMine.Checked;
+            Properties.Settings.Default.RandomizeMines = RandomizeMines;
+        }
+
+        private void cbPaz_CheckedChanged(object sender, EventArgs e)
+        {
+            flpPaz.Enabled = cbPazaak.Checked;
+            Properties.Settings.Default.RandomizePaz = RandomizePaz;
+        }
+
+        private void cbStims_CheckedChanged(object sender, EventArgs e)
+        {
+            flpStims.Enabled = cbStimulant.Checked;
+            Properties.Settings.Default.RandomizeStims = RandomizeStims;
+        }
+
+        private void cbUpgrade_CheckedChanged(object sender, EventArgs e)
+        {
+            flpUpgrades.Enabled = cbUpgrade.Checked;
+            Properties.Settings.Default.RandomizeUpgrade = RandomizeUpgrade;
+        }
+
+        private void cbVarious_CheckedChanged(object sender, EventArgs e)
+        {
+            flpVarious.Enabled = cbVarious.Checked;
+            Properties.Settings.Default.RandomizeVarious = RandomizeVarious;
+        }
+
+        // Form handlers
+        /// <summary>
+        /// Save appdata on form close. <para/>
+        /// (Now that I think about it, we only really need to save this once when the program closes.... oh well)
+        /// </summary>
         private void ItemForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.RandomizeArmor = (int)RandomizeArmor;
-            Properties.Settings.Default.RandomizeStims = (int)RandomizeStims;
-            Properties.Settings.Default.RandomizeBelts = (int)RandomizeBelts;
-            Properties.Settings.Default.RandomizeVarious = (int)RandomizeVarious;
-            Properties.Settings.Default.RandomizeHides = (int)RandomizeHides;
-            Properties.Settings.Default.RandomizeArmbands = (int)RandomizeArmbands;
-            Properties.Settings.Default.RandomizeDroid = (int)RandomizeDroid;
-            Properties.Settings.Default.RandomizeGloves = (int)RandomizeGloves;
-            Properties.Settings.Default.RandomizeImplants = (int)RandomizeImplants;
-            Properties.Settings.Default.RandomizeMask = (int)RandomizeMask;
-            Properties.Settings.Default.RandomizePaz = (int)RandomizePaz;
-            Properties.Settings.Default.RandomizeMines = (int)RandomizeMines;
-            Properties.Settings.Default.RandomizeUpgrade = (int)RandomizeUpgrade;
-            Properties.Settings.Default.RandomizeBlasters = (int)RandomizeBlasters;
-            Properties.Settings.Default.RandomizeCreature = (int)RandomizeCreature;
-            Properties.Settings.Default.RandomizeLightsabers = (int)RandomizeLightsabers;
-            Properties.Settings.Default.RandomizeGrenades = (int)RandomizeGrenades;
-            Properties.Settings.Default.RandomizeMelee = (int)RandomizeMelee;
-
             Properties.Settings.Default.Save();
         }
 
         private void ItemForm_Load(object sender, EventArgs e)
         {
-            //Auto-complete is cool
+            // Auto-complete is cool
             tbItemOmitAdd.AutoCompleteCustomSource.AddRange(Globals.ITEMS.ToArray());
         }
 
+        // Omitted item handlers
         private void bAddOmitItem_Click(object sender, EventArgs e)
         {
             Globals.OmitItems.Add(tbItemOmitAdd.Text);
@@ -1039,7 +1043,10 @@ namespace kotor_Randomizer_2
             }
         }
 
-        //Remove items from omit list. (Consider adding a restore default button in case they remove items that they didn't intend to.)
+        /// <summary>
+        /// Remove items from omit list. <para/>
+        /// (Consider adding a restore default button in case they remove items that they didn't intend to.)
+        /// </summary>
         private void lbOmitItems_MouseDoubleClick(object sender, MouseEventArgs e)
         {
             string[] to_remove = new string[lbOmitItems.SelectedItems.Count];
@@ -1059,6 +1066,7 @@ namespace kotor_Randomizer_2
             }
         }
 
+        // Toggle all handlers
         private void bToggleAll_Click(object sender, EventArgs e)
         {
             // If all checkboxes are checked, uncheck all of them. If any are unchecked, check all of them.
@@ -1109,6 +1117,72 @@ namespace kotor_Randomizer_2
                 rb.Checked = true;
             }
         }
+
+        // Radio button handlers
+        private void rbArmbandSType_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.RandomizeArmbands    = RandomizeArmbands; }
+        private void rbArmbandType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeArmbands    = RandomizeArmbands; }
+        private void rbArmbandMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeArmbands    = RandomizeArmbands; }
+
+        private void rbArmorSType_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeArmor       = RandomizeArmor; }
+        private void rbArmorType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeArmor       = RandomizeArmor; }
+        private void rbArmorMax_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeArmor       = RandomizeArmor; }
+
+        private void rbBeltType_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeBelts       = RandomizeBelts; }
+        private void rbBeltMax_CheckedChanged(object sender, EventArgs e)             { Properties.Settings.Default.RandomizeBelts       = RandomizeBelts; }
+
+        private void rbBlasterSType_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.RandomizeBlasters    = RandomizeBlasters; }
+        private void rbBlasterType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeBlasters    = RandomizeBlasters; }
+        private void rbBlasterMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeBlasters    = RandomizeBlasters; }
+
+        private void rbCreatureHideType_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.RandomizeHides       = RandomizeHides; }
+        private void rbCreatureHideMax_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.RandomizeHides       = RandomizeHides; }
+
+        private void rbCreatureWeaponSType_CheckedChanged(object sender, EventArgs e) { Properties.Settings.Default.RandomizeCreature    = RandomizeCreature; }
+        private void rbCreatureWeaponType_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.RandomizeCreature    = RandomizeCreature; }
+        private void rbCreatureWeaponMax_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.RandomizeCreature    = RandomizeCreature; }
+
+        private void rbDroidSType_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeDroid       = RandomizeDroid; }
+        private void rbDroidType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeDroid       = RandomizeDroid; }
+        private void rbDroidMax_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeDroid       = RandomizeDroid; }
+
+        private void rbGloveType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeGloves      = RandomizeGloves; }
+        private void rbGloveMax_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeGloves      = RandomizeGloves; }
+
+        private void rbGrenadeType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeGrenades    = RandomizeGrenades; }
+        private void rbGrenadeMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeGrenades    = RandomizeGrenades; }
+
+        private void rbImplantSType_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.RandomizeImplants    = RandomizeImplants; }
+        private void rbImplantType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeImplants    = RandomizeImplants; }
+        private void rbImplantMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeImplants    = RandomizeImplants; }
+
+        private void rbLightsaberSType_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.RandomizeLightsabers = RandomizeLightsabers; }
+        private void rbLightsaberType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.RandomizeLightsabers = RandomizeLightsabers; }
+        private void rbLightsaberMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.RandomizeLightsabers = RandomizeLightsabers; }
+
+        private void rbMaskSType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeMask        = RandomizeMask; }
+        private void rbMaskType_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeMask        = RandomizeMask; }
+        private void rbMaskMax_CheckedChanged(object sender, EventArgs e)             { Properties.Settings.Default.RandomizeMask        = RandomizeMask; }
+
+        private void rbMeleeSType_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeMelee       = RandomizeMelee; }
+        private void rbMeleeType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeMelee       = RandomizeMelee; }
+        private void rbMeleeMax_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeMelee       = RandomizeMelee; }
+
+        private void rbMineSType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeMines       = RandomizeMines; }
+        private void rbMineType_CheckedChanged(object sender, EventArgs e)            { Properties.Settings.Default.RandomizeMines       = RandomizeMines; }
+        private void rbMineMax_CheckedChanged(object sender, EventArgs e)             { Properties.Settings.Default.RandomizeMines       = RandomizeMines; }
+        private void rbPazaakType_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizePaz         = RandomizePaz; }
+        private void rbPazaakMax_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizePaz         = RandomizePaz; }
+
+        private void rbStimSType_CheckedChanged(object sender, EventArgs e)           { Properties.Settings.Default.RandomizeStims       = RandomizeStims; }
+        private void rbStimulantType_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.RandomizeStims       = RandomizeStims; }
+        private void rbStimulantMax_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.RandomizeStims       = RandomizeStims; }
+
+        private void rbUpgradeSType_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.RandomizeUpgrade     = RandomizeUpgrade; }
+        private void rbUpgradeType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeUpgrade     = RandomizeUpgrade; }
+        private void rbUpgradeMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeUpgrade     = RandomizeUpgrade; }
+
+        private void rbVariousType_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.RandomizeVarious     = RandomizeVarious; }
+        private void rbVariousMax_CheckedChanged(object sender, EventArgs e)          { Properties.Settings.Default.RandomizeVarious     = RandomizeVarious; }
 
         #endregion
     }

--- a/kotor Randomizer 2/Forms/PathForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/PathForm.Designer.cs
@@ -41,21 +41,21 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Unispace", 9.749999F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.749999F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.Location = new System.Drawing.Point(20, 23);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(71, 15);
+            this.label1.Size = new System.Drawing.Size(68, 16);
             this.label1.TabIndex = 0;
             this.label1.Text = "KotOR 1:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Unispace", 9.749999F, ((System.Drawing.FontStyle)(((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline) 
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.749999F, ((System.Drawing.FontStyle)(((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline) 
                 | System.Drawing.FontStyle.Strikeout))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.Location = new System.Drawing.Point(20, 53);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(71, 15);
+            this.label2.Size = new System.Drawing.Size(68, 16);
             this.label2.TabIndex = 1;
             this.label2.Text = "KotOR 2:";
             // 
@@ -67,6 +67,7 @@
             this.tbKotor1Path.Name = "tbKotor1Path";
             this.tbKotor1Path.Size = new System.Drawing.Size(470, 20);
             this.tbKotor1Path.TabIndex = 2;
+            this.tbKotor1Path.TextChanged += new System.EventHandler(this.tbKotor1Path_TextChanged);
             // 
             // tbKotor2Path
             // 
@@ -75,6 +76,7 @@
             this.tbKotor2Path.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.tbKotor2Path.Location = new System.Drawing.Point(100, 50);
             this.tbKotor2Path.Name = "tbKotor2Path";
+            this.tbKotor2Path.ReadOnly = true;
             this.tbKotor2Path.Size = new System.Drawing.Size(470, 20);
             this.tbKotor2Path.TabIndex = 3;
             this.tbKotor2Path.Text = "KotOR 2 randomization not currently available.";

--- a/kotor Randomizer 2/Forms/PathForm.cs
+++ b/kotor Randomizer 2/Forms/PathForm.cs
@@ -18,7 +18,7 @@ namespace kotor_Randomizer_2
             InitializeComponent();
 
             // Set up initial state from the previously saved settings.
-            tbKotor1Path.Text = Properties.Settings.Default.Kotor1Path;
+            Kotor1Path = Properties.Settings.Default.Kotor1Path;
         }
 
         public string Kotor1Path
@@ -27,21 +27,24 @@ namespace kotor_Randomizer_2
             set { tbKotor1Path.Text = value; }
         }
 
-        //I have my doubts that I will expand this to kotor II, but just in case.
+        // I have my doubts that I will expand this to kotor II, but just in case.
         public string Kotor2Path
         {
             get { return tbKotor2Path.Text; }
             set { tbKotor2Path.Text = value; }
         }
 
-
+        private void tbKotor1Path_TextChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.Kotor1Path = Kotor1Path;
+        }
 
         private void bKotor1PathBrowse_Click(object sender, EventArgs e)
         {
-            fbdKotor1.SelectedPath = tbKotor1Path.Text;
+            fbdKotor1.SelectedPath = Kotor1Path;
             if (fbdKotor1.ShowDialog() == DialogResult.OK)
             {
-                tbKotor1Path.Text = fbdKotor1.SelectedPath;
+                Kotor1Path = fbdKotor1.SelectedPath;
             }
         }
 
@@ -62,7 +65,7 @@ namespace kotor_Randomizer_2
                 DirectoryInfo di = new DirectoryInfo(path);
                 if (di.Exists)
                 {
-                    tbKotor1Path.Text = path;
+                    Kotor1Path = path;
                     K1PathFound = true;
                     break;
                 }
@@ -74,13 +77,12 @@ namespace kotor_Randomizer_2
             }
             else
             {
-                MessageBox.Show(this, "KotOR 1 path not found. Please enter it manually.");
+                MessageBox.Show(this, "KotOR 1 path not found. Please search for it manually.");
             }
         }
 
         private void PathForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.Kotor1Path = Kotor1Path;
             Properties.Settings.Default.Save();
         }
     }

--- a/kotor Randomizer 2/Forms/SoundForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/SoundForm.Designer.cs
@@ -214,6 +214,7 @@
             this.rbAreaMusicType.TabStop = true;
             this.rbAreaMusicType.Text = "Type";
             this.rbAreaMusicType.UseVisualStyleBackColor = true;
+            this.rbAreaMusicType.CheckedChanged += new System.EventHandler(this.rbAreaMusicType_CheckedChanged);
             // 
             // rbAreaMusicMax
             // 
@@ -224,6 +225,7 @@
             this.rbAreaMusicMax.TabIndex = 1;
             this.rbAreaMusicMax.Text = "Max";
             this.rbAreaMusicMax.UseVisualStyleBackColor = true;
+            this.rbAreaMusicMax.CheckedChanged += new System.EventHandler(this.rbAreaMusicMax_CheckedChanged);
             // 
             // flpCutsceneNoise
             // 
@@ -259,6 +261,7 @@
             this.rbCutsceneNoiseType.TabStop = true;
             this.rbCutsceneNoiseType.Text = "Type";
             this.rbCutsceneNoiseType.UseVisualStyleBackColor = true;
+            this.rbCutsceneNoiseType.CheckedChanged += new System.EventHandler(this.rbCutsceneNoiseType_CheckedChanged);
             // 
             // rbCutsceneNoiseMax
             // 
@@ -269,6 +272,7 @@
             this.rbCutsceneNoiseMax.TabIndex = 1;
             this.rbCutsceneNoiseMax.Text = "Max";
             this.rbCutsceneNoiseMax.UseVisualStyleBackColor = true;
+            this.rbCutsceneNoiseMax.CheckedChanged += new System.EventHandler(this.rbCutsceneNoiseMax_CheckedChanged);
             // 
             // flpAmbientNoise
             // 
@@ -304,6 +308,7 @@
             this.rbAmbientNoiseType.TabStop = true;
             this.rbAmbientNoiseType.Text = "Type";
             this.rbAmbientNoiseType.UseVisualStyleBackColor = true;
+            this.rbAmbientNoiseType.CheckedChanged += new System.EventHandler(this.rbAmbientNoiseType_CheckedChanged);
             // 
             // rbAmbientNoiseMax
             // 
@@ -314,6 +319,7 @@
             this.rbAmbientNoiseMax.TabIndex = 1;
             this.rbAmbientNoiseMax.Text = "Max";
             this.rbAmbientNoiseMax.UseVisualStyleBackColor = true;
+            this.rbAmbientNoiseMax.CheckedChanged += new System.EventHandler(this.rbAmbientNoiseMax_CheckedChanged);
             // 
             // flpBattleMusic
             // 
@@ -349,6 +355,7 @@
             this.rbBattleMusicType.TabStop = true;
             this.rbBattleMusicType.Text = "Type";
             this.rbBattleMusicType.UseVisualStyleBackColor = true;
+            this.rbBattleMusicType.CheckedChanged += new System.EventHandler(this.rbBattleMusicType_CheckedChanged);
             // 
             // rbBattleMusicMax
             // 
@@ -359,6 +366,7 @@
             this.rbBattleMusicMax.TabIndex = 1;
             this.rbBattleMusicMax.Text = "Max";
             this.rbBattleMusicMax.UseVisualStyleBackColor = true;
+            this.rbBattleMusicMax.CheckedChanged += new System.EventHandler(this.rbBattleMusicMax_CheckedChanged);
             // 
             // flpPartySounds
             // 
@@ -384,6 +392,7 @@
             this.rbPartySoundsActions.TabStop = true;
             this.rbPartySoundsActions.Text = "Actions";
             this.rbPartySoundsActions.UseVisualStyleBackColor = true;
+            this.rbPartySoundsActions.CheckedChanged += new System.EventHandler(this.rbPartySoundsActions_CheckedChanged);
             // 
             // rbPartySoundsType
             // 
@@ -394,6 +403,7 @@
             this.rbPartySoundsType.TabIndex = 0;
             this.rbPartySoundsType.Text = "Type";
             this.rbPartySoundsType.UseVisualStyleBackColor = true;
+            this.rbPartySoundsType.CheckedChanged += new System.EventHandler(this.rbPartySoundsType_CheckedChanged);
             // 
             // rbPartySoundsMax
             // 
@@ -404,6 +414,7 @@
             this.rbPartySoundsMax.TabIndex = 1;
             this.rbPartySoundsMax.Text = "Max";
             this.rbPartySoundsMax.UseVisualStyleBackColor = true;
+            this.rbPartySoundsMax.CheckedChanged += new System.EventHandler(this.rbPartySoundsMax_CheckedChanged);
             // 
             // flpNpcSounds
             // 

--- a/kotor Randomizer 2/Forms/SoundForm.cs
+++ b/kotor Randomizer 2/Forms/SoundForm.cs
@@ -18,14 +18,14 @@ namespace kotor_Randomizer_2
             cbMixNpcParty.Enabled = false;
             cbMixNpcParty.Visible = false;
 
-            RandomizeAreaMusic = (RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic;
-            RandomizeBattleMusic = (RandomizationLevel)Properties.Settings.Default.RandomizeBattleMusic;
-            RandomizeAmbientNoise = (RandomizationLevel)Properties.Settings.Default.RandomizeAmbientNoise;
-            RandomizeCutsceneNoise = (RandomizationLevel)Properties.Settings.Default.RandomizeCutsceneNoise;
-            //RandomizeNpcSounds = Properties.Settings.Default.RandomizeNpcSounds;
-            RandomizeNpcSounds = RandomizationLevel.None; // Functionality Disabled
-            RandomizePartySounds = (RandomizationLevel)Properties.Settings.Default.RandomizePartySounds;
-            cbRemoveDmca.Checked = Properties.Settings.Default.RemoveDmcaMusic;
+            RandomizeAreaMusic     = Properties.Settings.Default.RandomizeAreaMusic;
+            RandomizeBattleMusic   = Properties.Settings.Default.RandomizeBattleMusic;
+            RandomizeAmbientNoise  = Properties.Settings.Default.RandomizeAmbientNoise;
+            RandomizeCutsceneNoise = Properties.Settings.Default.RandomizeCutsceneNoise;
+            //RandomizeNpcSounds     = Properties.Settings.Default.RandomizeNpcSounds;
+            RandomizeNpcSounds     = RandomizationLevel.None;   // Functionality Disabled
+            RandomizePartySounds   = Properties.Settings.Default.RandomizePartySounds;
+            cbRemoveDmca.Checked   = Properties.Settings.Default.RemoveDmcaMusic;
 
             //MixNpcAndParty = Properties.Settings.Default.MixNpcAndPartySounds;
             MixNpcAndParty = false; // Functionality Disabled
@@ -322,37 +322,46 @@ namespace kotor_Randomizer_2
         private List<RadioButton> TypeRadioButtons = new List<RadioButton>();
         private List<RadioButton> MaxRadioButtons = new List<RadioButton>();
 
+        // Checkbox handlers
         private void cbAreaMusic_CheckedChanged(object sender, EventArgs e)
         {
             flpAreaMusic.Enabled = cbAreaMusic.Checked;
-        }
-
-        private void cbBattleMusic_CheckedChanged(object sender, EventArgs e)
-        {
-            flpBattleMusic.Enabled = cbBattleMusic.Checked;
+            Properties.Settings.Default.RandomizeAreaMusic = RandomizeAreaMusic;
         }
 
         private void cbAmbientNoise_CheckedChanged(object sender, EventArgs e)
         {
             flpAmbientNoise.Enabled = cbAmbientNoise.Checked;
+            Properties.Settings.Default.RandomizeAmbientNoise = RandomizeAmbientNoise;
+        }
+
+        private void cbBattleMusic_CheckedChanged(object sender, EventArgs e)
+        {
+            flpBattleMusic.Enabled = cbBattleMusic.Checked;
+            Properties.Settings.Default.RandomizeBattleMusic = RandomizeBattleMusic;
         }
 
         private void cbCutsceneNoise_CheckedChanged(object sender, EventArgs e)
         {
             flpCutsceneNoise.Enabled = cbCutsceneNoise.Checked;
+            Properties.Settings.Default.RandomizeCutsceneNoise = RandomizeCutsceneNoise;
         }
 
         private void cbNpcSounds_CheckedChanged(object sender, EventArgs e)
         {
             flpNpcSounds.Enabled = cbNpcSounds.Checked;
+            Properties.Settings.Default.RandomizeNpcSounds = RandomizeNpcSounds;
         }
 
         private void cbPartySounds_CheckedChanged(object sender, EventArgs e)
         {
-            if (!MixNpcAndParty)
-            {
-                flpPartySounds.Enabled = cbPartySounds.Checked;
-            }
+            flpPartySounds.Enabled = cbPartySounds.Checked;
+            Properties.Settings.Default.RandomizePartySounds = RandomizePartySounds;
+        }
+
+        private void cbRemoveDmca_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.RemoveDmcaMusic = cbRemoveDmca.Checked;
         }
 
         private void cbMixNpcParty_CheckedChanged(object sender, EventArgs e)
@@ -366,43 +375,25 @@ namespace kotor_Randomizer_2
             flpPartySounds.Visible = !isChecked;
         }
 
-        //I dont think these do anything, but glasnonck had them so i'm leaving em in
-        private void rbNpcSoundsActions_CheckedChanged(object sender, EventArgs e)
-        {
-            if (MixNpcAndParty)
-            {
-                rbPartySoundsActions.Checked = rbNpcSoundsActions.Checked;
-            }
-        }
-
-        private void rbNpcSoundsType_CheckedChanged(object sender, EventArgs e)
-        {
-            if (MixNpcAndParty)
-            {
-                rbPartySoundsType.Checked = rbNpcSoundsType.Checked;
-            }
-        }
-
-        private void rbNpcSoundsMax_CheckedChanged(object sender, EventArgs e)
-        {
-            if (MixNpcAndParty)
-            {
-                rbPartySoundsMax.Checked = rbNpcSoundsMax.Checked;
-            }
-        }
+        // Radio button handlers
+        private void rbAreaMusicType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.RandomizeAreaMusic     = RandomizeAreaMusic;     }
+        private void rbAreaMusicMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.RandomizeAreaMusic     = RandomizeAreaMusic;     }
+        private void rbAmbientNoiseType_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.RandomizeAmbientNoise  = RandomizeAmbientNoise;  }
+        private void rbAmbientNoiseMax_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.RandomizeAmbientNoise  = RandomizeAmbientNoise;  }
+        private void rbBattleMusicType_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.RandomizeBattleMusic   = RandomizeBattleMusic;   }
+        private void rbBattleMusicMax_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.RandomizeBattleMusic   = RandomizeBattleMusic;   }
+        private void rbCutsceneNoiseType_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.RandomizeCutsceneNoise = RandomizeCutsceneNoise; }
+        private void rbCutsceneNoiseMax_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.RandomizeCutsceneNoise = RandomizeCutsceneNoise; }
+        private void rbPartySoundsActions_CheckedChanged(object sender, EventArgs e) { Properties.Settings.Default.RandomizePartySounds   = RandomizePartySounds;   }
+        private void rbPartySoundsType_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.RandomizePartySounds   = RandomizePartySounds;   }
+        private void rbPartySoundsMax_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.RandomizePartySounds   = RandomizePartySounds;   }
 
         private void SoundForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.RandomizeAreaMusic = (int)RandomizeAreaMusic;
-            Properties.Settings.Default.RandomizeAmbientNoise = (int)RandomizeAmbientNoise;
-            Properties.Settings.Default.RandomizeBattleMusic = (int)RandomizeBattleMusic;
-            Properties.Settings.Default.RandomizeCutsceneNoise = (int)RandomizeCutsceneNoise;
-            Properties.Settings.Default.RandomizeNpcSounds = (int)RandomizeNpcSounds;
-            Properties.Settings.Default.RandomizePartySounds = (int)RandomizePartySounds;
-            Properties.Settings.Default.MixNpcAndPartySounds = MixNpcAndParty;
             Properties.Settings.Default.Save();
         }
 
+        // Toggle all handlers
         private void bToggleAll_Click(object sender, EventArgs e)
         {
             // If all checkboxes are checked, uncheck all of them. If any are unchecked, check all of them.
@@ -440,11 +431,6 @@ namespace kotor_Randomizer_2
             {
                 rb.Checked = true;
             }
-        }
-
-        private void cbRemoveDmca_CheckedChanged(object sender, EventArgs e)
-        {
-            Properties.Settings.Default.RemoveDmcaMusic = cbRemoveDmca.Checked;
         }
 
         #endregion

--- a/kotor Randomizer 2/Forms/StartForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/StartForm.Designer.cs
@@ -55,6 +55,7 @@
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.generateSpoilersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openSpoilersFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeAllOtherWindowsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.module_radio)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.item_radio)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sound_radio)).BeginInit();
@@ -423,14 +424,15 @@
             this.cms1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.helpToolStripMenuItem,
             this.generateSpoilersToolStripMenuItem,
-            this.openSpoilersFolderToolStripMenuItem});
+            this.openSpoilersFolderToolStripMenuItem,
+            this.closeAllOtherWindowsToolStripMenuItem});
             this.cms1.Name = "contextMenuStrip1";
-            this.cms1.Size = new System.Drawing.Size(181, 92);
+            this.cms1.Size = new System.Drawing.Size(192, 114);
             // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.helpToolStripMenuItem.Text = "Help";
             this.helpToolStripMenuItem.Click += new System.EventHandler(this.helpToolStripMenuItem_Click);
             // 
@@ -438,16 +440,23 @@
             // 
             this.generateSpoilersToolStripMenuItem.Enabled = false;
             this.generateSpoilersToolStripMenuItem.Name = "generateSpoilersToolStripMenuItem";
-            this.generateSpoilersToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.generateSpoilersToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.generateSpoilersToolStripMenuItem.Text = "Generate Spoilers";
             this.generateSpoilersToolStripMenuItem.Click += new System.EventHandler(this.generateSpoilersToolStripMenuItem_Click);
             // 
             // openSpoilersFolderToolStripMenuItem
             // 
             this.openSpoilersFolderToolStripMenuItem.Name = "openSpoilersFolderToolStripMenuItem";
-            this.openSpoilersFolderToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.openSpoilersFolderToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.openSpoilersFolderToolStripMenuItem.Text = "Open Spoilers Folder";
             this.openSpoilersFolderToolStripMenuItem.Click += new System.EventHandler(this.openSpoilersFolderToolStripMenuItem_Click);
+            // 
+            // closeAllOtherWindowsToolStripMenuItem
+            // 
+            this.closeAllOtherWindowsToolStripMenuItem.Name = "closeAllOtherWindowsToolStripMenuItem";
+            this.closeAllOtherWindowsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.closeAllOtherWindowsToolStripMenuItem.Text = "Close All Other Windows";
+            this.closeAllOtherWindowsToolStripMenuItem.Click += new System.EventHandler(this.closeAllOtherWindowsToolStripMenuItem_Click);
             // 
             // StartForm
             // 
@@ -527,6 +536,7 @@
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem generateSpoilersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openSpoilersFolderToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem closeAllOtherWindowsToolStripMenuItem;
     }
 }
 

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -271,6 +271,19 @@ namespace kotor_Randomizer_2
         {
             if (false == FocusOpenForm<RandoForm>())
             {
+                if (!Directory.Exists(Properties.Settings.Default.Kotor1Path))
+                {
+                    // Kotor1Path directory doesn't exist.
+                    MessageBox.Show(this, "Kotor 1 path does not exist. Please update your path settings.", "Path Error");
+                    return;
+                }
+                else if (!File.Exists(Path.Combine(Properties.Settings.Default.Kotor1Path, "swkotor.exe")))
+                {
+                    // Kotor1Path directory doesn't contain swkotor.exe.
+                    MessageBox.Show(this, "Kotor 1 path does not contain 'swkotor.exe' and is therefore an invalid directory. Please update your path settings.", "Path Error");
+                    return;
+                }
+
                 if (Properties.Settings.Default.KotorIsRandomized)
                 {
                     randomize_button.Text = "Randomize!";

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 using System.IO;
 using ClosedXML.Excel;
+using System.Collections.Generic;
 
 namespace kotor_Randomizer_2
 {
@@ -88,11 +89,11 @@ namespace kotor_Randomizer_2
                     wsList.Remove(wsList.Length - 2, 2);
 
                     workbook.SaveAs(path);
-                    MessageBox.Show($"Spoiler logs created: {wsList.ToString()}");
+                    MessageBox.Show($"Spoiler logs created: {wsList.ToString()}", Properties.Resources.GenerateSpoilerLogs);
                 }
                 else
                 {
-                    MessageBox.Show($"No spoiler logs created. Either the game has not been randomized, or the selected randomizations do not generate spoilers.");
+                    MessageBox.Show($"No spoiler logs created. Either the game has not been randomized, or the selected randomizations do not generate spoilers.", Properties.Resources.GenerateSpoilerLogs);
                 }
             }
         }
@@ -311,6 +312,24 @@ namespace kotor_Randomizer_2
             var dir = Path.Combine(Environment.CurrentDirectory, "Spoilers");
             Directory.CreateDirectory(dir); // Does nothing if directory exists.
             System.Diagnostics.Process.Start(dir);
+        }
+
+        private void closeAllOtherWindowsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var formsToClose = new List<Form>();
+            foreach (Form f in Application.OpenForms)
+            {
+                if (f is StartForm)
+                {
+                    continue;
+                }
+                formsToClose.Add(f);
+            }
+
+            for (int i = 0; i < formsToClose.Count; i++)
+            {
+                formsToClose[i].Close();
+            }
         }
         #endregion
     }

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -332,10 +332,8 @@ namespace kotor_Randomizer_2
             var formsToClose = new List<Form>();
             foreach (Form f in Application.OpenForms)
             {
-                if (f is StartForm)
-                {
-                    continue;
-                }
+                if (f is StartForm) continue;
+                if (f is RandoForm && (f as RandoForm).IsInProgress) continue;
                 formsToClose.Add(f);
             }
 

--- a/kotor Randomizer 2/Forms/TextureForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/TextureForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TextureForm));
             this.cbCubeMaps = new System.Windows.Forms.CheckBox();
             this.flpCubeMaps = new System.Windows.Forms.FlowLayoutPanel();
@@ -95,6 +96,7 @@
             this.bToggleAll = new System.Windows.Forms.Button();
             this.bAllMax = new System.Windows.Forms.Button();
             this.bTypeAll = new System.Windows.Forms.Button();
+            this.TexturesToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.flpCubeMaps.SuspendLayout();
             this.flpCreatures.SuspendLayout();
             this.flpEffects.SuspendLayout();
@@ -122,6 +124,8 @@
             this.cbCubeMaps.Size = new System.Drawing.Size(120, 20);
             this.cbCubeMaps.TabIndex = 1;
             this.cbCubeMaps.Text = "Cube Maps";
+            this.TexturesToolTip.SetToolTip(this.cbCubeMaps, "A simple texture used to generate the faint image seen\r\nin the reflection of shin" +
+        "y objects.");
             this.cbCubeMaps.UseVisualStyleBackColor = true;
             this.cbCubeMaps.CheckedChanged += new System.EventHandler(this.cbCubeMaps_CheckedChanged);
             // 
@@ -149,6 +153,7 @@
             this.rbCubeMapsType.TabStop = true;
             this.rbCubeMapsType.Text = "Type";
             this.rbCubeMapsType.UseVisualStyleBackColor = true;
+            this.rbCubeMapsType.CheckedChanged += new System.EventHandler(this.rbCubeMapsType_CheckedChanged);
             // 
             // rbCubeMapsMax
             // 
@@ -160,6 +165,7 @@
             this.rbCubeMapsMax.Tag = "";
             this.rbCubeMapsMax.Text = "Max";
             this.rbCubeMapsMax.UseVisualStyleBackColor = true;
+            this.rbCubeMapsMax.CheckedChanged += new System.EventHandler(this.rbCubeMapsMax_CheckedChanged);
             // 
             // flpCreatures
             // 
@@ -185,6 +191,7 @@
             this.rbCreaturesType.TabStop = true;
             this.rbCreaturesType.Text = "Type";
             this.rbCreaturesType.UseVisualStyleBackColor = true;
+            this.rbCreaturesType.CheckedChanged += new System.EventHandler(this.rbCreaturesType_CheckedChanged);
             // 
             // rbCreaturesMax
             // 
@@ -195,6 +202,7 @@
             this.rbCreaturesMax.TabIndex = 1;
             this.rbCreaturesMax.Text = "Max";
             this.rbCreaturesMax.UseVisualStyleBackColor = true;
+            this.rbCreaturesMax.CheckedChanged += new System.EventHandler(this.rbCreaturesMax_CheckedChanged);
             // 
             // cbCreatures
             // 
@@ -206,6 +214,7 @@
             this.cbCreatures.Size = new System.Drawing.Size(120, 20);
             this.cbCreatures.TabIndex = 20;
             this.cbCreatures.Text = "Creatures";
+            this.TexturesToolTip.SetToolTip(this.cbCreatures, "The maps used to texture creatures.");
             this.cbCreatures.UseVisualStyleBackColor = true;
             this.cbCreatures.CheckedChanged += new System.EventHandler(this.cbCreatures_CheckedChanged);
             // 
@@ -233,6 +242,7 @@
             this.rbEffectsType.TabStop = true;
             this.rbEffectsType.Text = "Type";
             this.rbEffectsType.UseVisualStyleBackColor = true;
+            this.rbEffectsType.CheckedChanged += new System.EventHandler(this.rbEffectsType_CheckedChanged);
             // 
             // rbEffectsMax
             // 
@@ -243,6 +253,7 @@
             this.rbEffectsMax.TabIndex = 1;
             this.rbEffectsMax.Text = "Max";
             this.rbEffectsMax.UseVisualStyleBackColor = true;
+            this.rbEffectsMax.CheckedChanged += new System.EventHandler(this.rbEffectsMax_CheckedChanged);
             // 
             // cbEffects
             // 
@@ -254,6 +265,7 @@
             this.cbEffects.Size = new System.Drawing.Size(120, 20);
             this.cbEffects.TabIndex = 22;
             this.cbEffects.Text = "Effects";
+            this.TexturesToolTip.SetToolTip(this.cbEffects, "All files prefixed with FX, usually rays of light and other\r\nspecial events.");
             this.cbEffects.UseVisualStyleBackColor = true;
             this.cbEffects.CheckedChanged += new System.EventHandler(this.cbEffects_CheckedChanged);
             // 
@@ -281,6 +293,7 @@
             this.rbItemsType.TabStop = true;
             this.rbItemsType.Text = "Type";
             this.rbItemsType.UseVisualStyleBackColor = true;
+            this.rbItemsType.CheckedChanged += new System.EventHandler(this.rbItemsType_CheckedChanged);
             // 
             // rbItemsMax
             // 
@@ -291,6 +304,7 @@
             this.rbItemsMax.TabIndex = 1;
             this.rbItemsMax.Text = "Max";
             this.rbItemsMax.UseVisualStyleBackColor = true;
+            this.rbItemsMax.CheckedChanged += new System.EventHandler(this.rbItemsMax_CheckedChanged);
             // 
             // cbItems
             // 
@@ -302,6 +316,8 @@
             this.cbItems.Size = new System.Drawing.Size(120, 20);
             this.cbItems.TabIndex = 20;
             this.cbItems.Text = "Items";
+            this.TexturesToolTip.SetToolTip(this.cbItems, "The 3D rendered image of items. Most of these go unused\r\nin the game as the 3D va" +
+        "riants of many items never see\r\nuse.");
             this.cbItems.UseVisualStyleBackColor = true;
             this.cbItems.CheckedChanged += new System.EventHandler(this.cbItems_CheckedChanged);
             // 
@@ -329,6 +345,7 @@
             this.rbPlanetaryType.TabStop = true;
             this.rbPlanetaryType.Text = "Type";
             this.rbPlanetaryType.UseVisualStyleBackColor = true;
+            this.rbPlanetaryType.CheckedChanged += new System.EventHandler(this.rbPlanetaryType_CheckedChanged);
             // 
             // rbPlanetaryMax
             // 
@@ -339,6 +356,7 @@
             this.rbPlanetaryMax.TabIndex = 1;
             this.rbPlanetaryMax.Text = "Max";
             this.rbPlanetaryMax.UseVisualStyleBackColor = true;
+            this.rbPlanetaryMax.CheckedChanged += new System.EventHandler(this.rbPlanetaryMax_CheckedChanged);
             // 
             // cbPlanetary
             // 
@@ -350,6 +368,7 @@
             this.cbPlanetary.Size = new System.Drawing.Size(120, 20);
             this.cbPlanetary.TabIndex = 24;
             this.cbPlanetary.Text = "Planetary";
+            this.TexturesToolTip.SetToolTip(this.cbPlanetary, "Textures that are tied to a specific planet.");
             this.cbPlanetary.UseVisualStyleBackColor = true;
             this.cbPlanetary.CheckedChanged += new System.EventHandler(this.cbPlanetary_CheckedChanged);
             // 
@@ -377,6 +396,7 @@
             this.rbNPCType.TabStop = true;
             this.rbNPCType.Text = "Type";
             this.rbNPCType.UseVisualStyleBackColor = true;
+            this.rbNPCType.CheckedChanged += new System.EventHandler(this.rbNPCType_CheckedChanged);
             // 
             // rbNPCMax
             // 
@@ -387,6 +407,7 @@
             this.rbNPCMax.TabIndex = 1;
             this.rbNPCMax.Text = "Max";
             this.rbNPCMax.UseVisualStyleBackColor = true;
+            this.rbNPCMax.CheckedChanged += new System.EventHandler(this.rbNPCMax_CheckedChanged);
             // 
             // cbNPC
             // 
@@ -398,6 +419,7 @@
             this.cbNPC.Size = new System.Drawing.Size(120, 20);
             this.cbNPC.TabIndex = 26;
             this.cbNPC.Text = "NPC";
+            this.TexturesToolTip.SetToolTip(this.cbNPC, "Textures used by NPCs.");
             this.cbNPC.UseVisualStyleBackColor = true;
             this.cbNPC.CheckedChanged += new System.EventHandler(this.cbNPC_CheckedChanged);
             // 
@@ -425,6 +447,7 @@
             this.rbPlayHeadsType.TabStop = true;
             this.rbPlayHeadsType.Text = "Type";
             this.rbPlayHeadsType.UseVisualStyleBackColor = true;
+            this.rbPlayHeadsType.CheckedChanged += new System.EventHandler(this.rbPlayHeadsType_CheckedChanged);
             // 
             // rbPlayHeadsMax
             // 
@@ -435,6 +458,7 @@
             this.rbPlayHeadsMax.TabIndex = 1;
             this.rbPlayHeadsMax.Text = "Max";
             this.rbPlayHeadsMax.UseVisualStyleBackColor = true;
+            this.rbPlayHeadsMax.CheckedChanged += new System.EventHandler(this.rbPlayHeadsMax_CheckedChanged);
             // 
             // cbPlayHeads
             // 
@@ -446,6 +470,7 @@
             this.cbPlayHeads.Size = new System.Drawing.Size(120, 20);
             this.cbPlayHeads.TabIndex = 28;
             this.cbPlayHeads.Text = "Player Heads";
+            this.TexturesToolTip.SetToolTip(this.cbPlayHeads, "Textures for the heads of all the player models.");
             this.cbPlayHeads.UseVisualStyleBackColor = true;
             this.cbPlayHeads.CheckedChanged += new System.EventHandler(this.cbPlayHeads_CheckedChanged);
             // 
@@ -473,6 +498,7 @@
             this.rbPlayBodiesType.TabStop = true;
             this.rbPlayBodiesType.Text = "Type";
             this.rbPlayBodiesType.UseVisualStyleBackColor = true;
+            this.rbPlayBodiesType.CheckedChanged += new System.EventHandler(this.rbPlayBodiesType_CheckedChanged);
             // 
             // rbPlayBodiesMax
             // 
@@ -483,6 +509,7 @@
             this.rbPlayBodiesMax.TabIndex = 1;
             this.rbPlayBodiesMax.Text = "Max";
             this.rbPlayBodiesMax.UseVisualStyleBackColor = true;
+            this.rbPlayBodiesMax.CheckedChanged += new System.EventHandler(this.rbPlayBodiesMax_CheckedChanged);
             // 
             // cbPlayBodies
             // 
@@ -494,6 +521,7 @@
             this.cbPlayBodies.Size = new System.Drawing.Size(120, 20);
             this.cbPlayBodies.TabIndex = 30;
             this.cbPlayBodies.Text = "Player Bodies";
+            this.TexturesToolTip.SetToolTip(this.cbPlayBodies, "Textures for the bodies of all the player models.");
             this.cbPlayBodies.UseVisualStyleBackColor = true;
             this.cbPlayBodies.CheckedChanged += new System.EventHandler(this.cbPlayBodies_CheckedChanged);
             // 
@@ -521,6 +549,7 @@
             this.rbPlaceablesType.TabStop = true;
             this.rbPlaceablesType.Text = "Type";
             this.rbPlaceablesType.UseVisualStyleBackColor = true;
+            this.rbPlaceablesType.CheckedChanged += new System.EventHandler(this.rbPlaceablesType_CheckedChanged);
             // 
             // rbPlaceablesMax
             // 
@@ -531,6 +560,7 @@
             this.rbPlaceablesMax.TabIndex = 1;
             this.rbPlaceablesMax.Text = "Max";
             this.rbPlaceablesMax.UseVisualStyleBackColor = true;
+            this.rbPlaceablesMax.CheckedChanged += new System.EventHandler(this.rbPlaceablesMax_CheckedChanged);
             // 
             // cbPlaceables
             // 
@@ -542,6 +572,8 @@
             this.cbPlaceables.Size = new System.Drawing.Size(120, 20);
             this.cbPlaceables.TabIndex = 32;
             this.cbPlaceables.Text = "Placeables";
+            this.TexturesToolTip.SetToolTip(this.cbPlaceables, "Textures of placeable objects such as footlockers, computer\r\nconsoles, marker pos" +
+        "ts, etc.");
             this.cbPlaceables.UseVisualStyleBackColor = true;
             this.cbPlaceables.CheckedChanged += new System.EventHandler(this.cbPlaceables_CheckedChanged);
             // 
@@ -569,6 +601,7 @@
             this.rbPartyType.TabStop = true;
             this.rbPartyType.Text = "Type";
             this.rbPartyType.UseVisualStyleBackColor = true;
+            this.rbPartyType.CheckedChanged += new System.EventHandler(this.rbPartyType_CheckedChanged);
             // 
             // rbPartyMax
             // 
@@ -579,6 +612,7 @@
             this.rbPartyMax.TabIndex = 1;
             this.rbPartyMax.Text = "Max";
             this.rbPartyMax.UseVisualStyleBackColor = true;
+            this.rbPartyMax.CheckedChanged += new System.EventHandler(this.rbPartyMax_CheckedChanged);
             // 
             // cbParty
             // 
@@ -590,6 +624,7 @@
             this.cbParty.Size = new System.Drawing.Size(120, 20);
             this.cbParty.TabIndex = 34;
             this.cbParty.Text = "Party";
+            this.TexturesToolTip.SetToolTip(this.cbParty, "Textures used by party members.");
             this.cbParty.UseVisualStyleBackColor = true;
             this.cbParty.CheckedChanged += new System.EventHandler(this.cbParty_CheckedChanged);
             // 
@@ -617,6 +652,7 @@
             this.rbStuntType.TabStop = true;
             this.rbStuntType.Text = "Type";
             this.rbStuntType.UseVisualStyleBackColor = true;
+            this.rbStuntType.CheckedChanged += new System.EventHandler(this.rbStuntType_CheckedChanged);
             // 
             // rbStuntMax
             // 
@@ -627,6 +663,7 @@
             this.rbStuntMax.TabIndex = 1;
             this.rbStuntMax.Text = "Max";
             this.rbStuntMax.UseVisualStyleBackColor = true;
+            this.rbStuntMax.CheckedChanged += new System.EventHandler(this.rbStuntMax_CheckedChanged);
             // 
             // cbStunt
             // 
@@ -638,6 +675,7 @@
             this.cbStunt.Size = new System.Drawing.Size(120, 20);
             this.cbStunt.TabIndex = 36;
             this.cbStunt.Text = "Stunt";
+            this.TexturesToolTip.SetToolTip(this.cbStunt, "Textures used in STUNT (cutscene) modules.");
             this.cbStunt.UseVisualStyleBackColor = true;
             this.cbStunt.CheckedChanged += new System.EventHandler(this.cbStunt_CheckedChanged);
             // 
@@ -665,6 +703,7 @@
             this.rbVehiclesType.TabStop = true;
             this.rbVehiclesType.Text = "Type";
             this.rbVehiclesType.UseVisualStyleBackColor = true;
+            this.rbVehiclesType.CheckedChanged += new System.EventHandler(this.rbVehiclesType_CheckedChanged);
             // 
             // rbVehiclesMax
             // 
@@ -675,6 +714,7 @@
             this.rbVehiclesMax.TabIndex = 1;
             this.rbVehiclesMax.Text = "Max";
             this.rbVehiclesMax.UseVisualStyleBackColor = true;
+            this.rbVehiclesMax.CheckedChanged += new System.EventHandler(this.rbVehiclesMax_CheckedChanged);
             // 
             // cbVehicles
             // 
@@ -686,6 +726,7 @@
             this.cbVehicles.Size = new System.Drawing.Size(120, 20);
             this.cbVehicles.TabIndex = 38;
             this.cbVehicles.Text = "Vehicles";
+            this.TexturesToolTip.SetToolTip(this.cbVehicles, "Textures used by vehicles.");
             this.cbVehicles.UseVisualStyleBackColor = true;
             this.cbVehicles.CheckedChanged += new System.EventHandler(this.cbVehicles_CheckedChanged);
             // 
@@ -713,6 +754,7 @@
             this.rbWeaponsType.TabStop = true;
             this.rbWeaponsType.Text = "Type";
             this.rbWeaponsType.UseVisualStyleBackColor = true;
+            this.rbWeaponsType.CheckedChanged += new System.EventHandler(this.rbWeaponsType_CheckedChanged);
             // 
             // rbWeaponsMax
             // 
@@ -723,6 +765,7 @@
             this.rbWeaponsMax.TabIndex = 1;
             this.rbWeaponsMax.Text = "Max";
             this.rbWeaponsMax.UseVisualStyleBackColor = true;
+            this.rbWeaponsMax.CheckedChanged += new System.EventHandler(this.rbWeaponsMax_CheckedChanged);
             // 
             // cbWeapons
             // 
@@ -734,6 +777,7 @@
             this.cbWeapons.Size = new System.Drawing.Size(120, 20);
             this.cbWeapons.TabIndex = 40;
             this.cbWeapons.Text = "Weapons";
+            this.TexturesToolTip.SetToolTip(this.cbWeapons, "Textures used in the 3D rendering of weapons.");
             this.cbWeapons.UseVisualStyleBackColor = true;
             this.cbWeapons.CheckedChanged += new System.EventHandler(this.cbWeapons_CheckedChanged);
             // 
@@ -761,6 +805,7 @@
             this.rbOtherType.TabStop = true;
             this.rbOtherType.Text = "Type";
             this.rbOtherType.UseVisualStyleBackColor = true;
+            this.rbOtherType.CheckedChanged += new System.EventHandler(this.rbOtherType_CheckedChanged);
             // 
             // rbOtherMax
             // 
@@ -771,6 +816,7 @@
             this.rbOtherMax.TabIndex = 1;
             this.rbOtherMax.Text = "Max";
             this.rbOtherMax.UseVisualStyleBackColor = true;
+            this.rbOtherMax.CheckedChanged += new System.EventHandler(this.rbOtherMax_CheckedChanged);
             // 
             // cbOther
             // 
@@ -782,6 +828,8 @@
             this.cbOther.Size = new System.Drawing.Size(120, 20);
             this.cbOther.TabIndex = 42;
             this.cbOther.Text = "Other";
+            this.TexturesToolTip.SetToolTip(this.cbOther, "Anything that does not fall into one of the other categories\r\n(there are quite a " +
+        "few, actually).");
             this.cbOther.UseVisualStyleBackColor = true;
             this.cbOther.CheckedChanged += new System.EventHandler(this.cbOther_CheckedChanged);
             // 
@@ -806,6 +854,7 @@
             this.rbTextLow.TabStop = true;
             this.rbTextLow.Text = "Low Quality";
             this.rbTextLow.UseVisualStyleBackColor = true;
+            this.rbTextLow.CheckedChanged += new System.EventHandler(this.rbTextLow_CheckedChanged);
             // 
             // rbTextMed
             // 
@@ -817,6 +866,7 @@
             this.rbTextMed.TabStop = true;
             this.rbTextMed.Text = "Med Quality";
             this.rbTextMed.UseVisualStyleBackColor = true;
+            this.rbTextMed.CheckedChanged += new System.EventHandler(this.rbTextMed_CheckedChanged);
             // 
             // rbTextHigh
             // 
@@ -829,6 +879,7 @@
             this.rbTextHigh.TabStop = true;
             this.rbTextHigh.Text = "High Quality";
             this.rbTextHigh.UseVisualStyleBackColor = true;
+            this.rbTextHigh.CheckedChanged += new System.EventHandler(this.rbTextHigh_CheckedChanged);
             // 
             // label1
             // 
@@ -842,6 +893,7 @@
             // 
             // lWarning
             // 
+            this.lWarning.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lWarning.Location = new System.Drawing.Point(280, 360);
             this.lWarning.Name = "lWarning";
             this.lWarning.Size = new System.Drawing.Size(110, 110);
@@ -851,6 +903,7 @@
             // 
             // label2
             // 
+            this.label2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.label2.Location = new System.Drawing.Point(280, 150);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(110, 200);
@@ -1050,5 +1103,6 @@
         private System.Windows.Forms.Button bToggleAll;
         private System.Windows.Forms.Button bAllMax;
         private System.Windows.Forms.Button bTypeAll;
+        private System.Windows.Forms.ToolTip TexturesToolTip;
     }
 }

--- a/kotor Randomizer 2/Forms/TextureForm.cs
+++ b/kotor Randomizer 2/Forms/TextureForm.cs
@@ -11,37 +11,37 @@ namespace kotor_Randomizer_2
         {
             InitializeComponent();
 
-            //Set Initial Values
-            RandomizeCubeMaps = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeCubeMaps;
-            RandomizeCreatures = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeCreatures;
-            RandomizeEffects = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeEffects;
-            RandomizeItems = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeItems;
-            RandomizePlanetary = (RandomizationLevel)Properties.Settings.Default.TextureRandomizePlanetary;
-            RandomizeNPC = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeNPC;
-            RandomizePlayHeads = (RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayHeads;
-            RandomizePlayBodies = (RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayBodies;
-            RandomizePlaceables = (RandomizationLevel)Properties.Settings.Default.TextureRandomizePlaceables;
-            RandomizeParty = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeParty;
-            RandomizeStunt = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeStunt;
-            RandomizeVehicles = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeVehicles;
-            RandomizeWeapons = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeWeapons;
-            RandomizeOther = (RandomizationLevel)Properties.Settings.Default.TextureRandomizeOther;
+            // Set Initial Values
+            RandomizeCubeMaps = Properties.Settings.Default.TextureRandomizeCubeMaps;
+            RandomizeCreatures = Properties.Settings.Default.TextureRandomizeCreatures;
+            RandomizeEffects = Properties.Settings.Default.TextureRandomizeEffects;
+            RandomizeItems = Properties.Settings.Default.TextureRandomizeItems;
+            RandomizePlanetary = Properties.Settings.Default.TextureRandomizePlanetary;
+            RandomizeNPC = Properties.Settings.Default.TextureRandomizeNPC;
+            RandomizePlayHeads = Properties.Settings.Default.TextureRandomizePlayHeads;
+            RandomizePlayBodies = Properties.Settings.Default.TextureRandomizePlayBodies;
+            RandomizePlaceables = Properties.Settings.Default.TextureRandomizePlaceables;
+            RandomizeParty = Properties.Settings.Default.TextureRandomizeParty;
+            RandomizeStunt = Properties.Settings.Default.TextureRandomizeStunt;
+            RandomizeVehicles = Properties.Settings.Default.TextureRandomizeVehicles;
+            RandomizeWeapons = Properties.Settings.Default.TextureRandomizeWeapons;
+            RandomizeOther = Properties.Settings.Default.TextureRandomizeOther;
 
-            //Radio switch for which texture pack is to be randomized.
-            //Right now its set up to only allow the user to randomize one of the 3 texture packs in the game. Primariliy because most
-            //people only use the high quality pack, and also if there are stability issues this allows them to switch to a stable pack
-            //in-game, without opening this program up.
+            // Radio switch for which texture pack is to be randomized.
+            // Right now its set up to only allow the user to randomize one of the 3 texture packs in the game. Primarily because most
+            // people only use the high quality pack, and also if there are stability issues this allows them to switch to a stable pack
+            // in-game, without opening this program up.
             switch (Properties.Settings.Default.TexturePack)
             {
-                case 1:
+                default:
+                case TexturePack.HighQuality:
+                    rbTextHigh.Checked = true;
+                    break;
+                case TexturePack.MedQuality:
                     rbTextMed.Checked = true;
                     break;
-                case 2:
+                case TexturePack.LowQuality:
                     rbTextLow.Checked = true;
-                    break;
-                default:
-                case 0:
-                    rbTextHigh.Checked = true;
                     break;
             }
 
@@ -655,100 +655,145 @@ namespace kotor_Randomizer_2
         private List<RadioButton> TypeRadioButtons = new List<RadioButton>();
         private List<RadioButton> MaxRadioButtons = new List<RadioButton>();
 
+        // Checkbox event handlers
         private void cbCubeMaps_CheckedChanged(object sender, EventArgs e)
         {
             flpCubeMaps.Enabled = cbCubeMaps.Checked;
+            Properties.Settings.Default.TextureRandomizeCubeMaps = RandomizeCubeMaps;
         }
 
         private void cbCreatures_CheckedChanged(object sender, EventArgs e)
         {
             flpCreatures.Enabled = cbCreatures.Checked;
+            Properties.Settings.Default.TextureRandomizeCreatures = RandomizeCreatures;
         }
 
         private void cbEffects_CheckedChanged(object sender, EventArgs e)
         {
             flpEffects.Enabled = cbEffects.Checked;
+            Properties.Settings.Default.TextureRandomizeEffects = RandomizeEffects;
         }
 
         private void cbItems_CheckedChanged(object sender, EventArgs e)
         {
             flpItems.Enabled = cbItems.Checked;
+            Properties.Settings.Default.TextureRandomizeItems = RandomizeItems;
         }
 
         private void cbPlanetary_CheckedChanged(object sender, EventArgs e)
         {
             flpPlanetary.Enabled = cbPlanetary.Checked;
+            Properties.Settings.Default.TextureRandomizePlanetary = RandomizePlanetary;
         }
 
         private void cbNPC_CheckedChanged(object sender, EventArgs e)
         {
             flpNPC.Enabled = cbNPC.Checked;
+            Properties.Settings.Default.TextureRandomizeNPC = RandomizeNPC;
         }
 
         private void cbPlayHeads_CheckedChanged(object sender, EventArgs e)
         {
             flpPlayHeads.Enabled = cbPlayHeads.Checked;
+            Properties.Settings.Default.TextureRandomizePlayHeads = RandomizePlayHeads;
         }
 
         private void cbPlayBodies_CheckedChanged(object sender, EventArgs e)
         {
             flpPlayBodies.Enabled = cbPlayBodies.Checked;
+            Properties.Settings.Default.TextureRandomizePlayBodies = RandomizePlayBodies;
         }
 
         private void cbPlaceables_CheckedChanged(object sender, EventArgs e)
         {
             flpPlaceables.Enabled = cbPlaceables.Checked;
+            Properties.Settings.Default.TextureRandomizePlaceables = RandomizePlaceables;
         }
 
         private void cbParty_CheckedChanged(object sender, EventArgs e)
         {
             flpParty.Enabled = cbParty.Checked;
+            Properties.Settings.Default.TextureRandomizeParty = RandomizeParty;
         }
 
         private void cbStunt_CheckedChanged(object sender, EventArgs e)
         {
             flpStunt.Enabled = cbStunt.Checked;
+            Properties.Settings.Default.TextureRandomizeStunt = RandomizeStunt;
         }
 
         private void cbVehicles_CheckedChanged(object sender, EventArgs e)
         {
             flpVehicles.Enabled = cbVehicles.Checked;
+            Properties.Settings.Default.TextureRandomizeVehicles = RandomizeVehicles;
         }
 
         private void cbWeapons_CheckedChanged(object sender, EventArgs e)
         {
             flpWeapons.Enabled = cbWeapons.Checked;
+            Properties.Settings.Default.TextureRandomizeWeapons = RandomizeWeapons;
         }
 
         private void cbOther_CheckedChanged(object sender, EventArgs e)
         {
             flpOther.Enabled = cbOther.Checked;
+            Properties.Settings.Default.TextureRandomizeOther = RandomizeOther;
         }
 
+        // Radio button event handlers
+        private void rbCubeMapsType_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.TextureRandomizeCubeMaps   = RandomizeCubeMaps; }
+        private void rbCubeMapsMax_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.TextureRandomizeCubeMaps   = RandomizeCubeMaps; }
+
+        private void rbCreaturesType_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TextureRandomizeCreatures  = RandomizeCreatures; }
+        private void rbCreaturesMax_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.TextureRandomizeCreatures  = RandomizeCreatures; }
+
+        private void rbEffectsType_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.TextureRandomizeEffects    = RandomizeEffects; }
+        private void rbEffectsMax_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.TextureRandomizeEffects    = RandomizeEffects; }
+
+        private void rbItemsType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.TextureRandomizeItems      = RandomizeItems; }
+        private void rbItemsMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.TextureRandomizeItems      = RandomizeItems; }
+
+        private void rbPlanetaryType_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TextureRandomizePlanetary  = RandomizePlanetary; }
+        private void rbPlanetaryMax_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.TextureRandomizePlanetary  = RandomizePlanetary; }
+
+        private void rbNPCType_CheckedChanged(object sender, EventArgs e)        { Properties.Settings.Default.TextureRandomizeNPC        = RandomizeNPC; }
+        private void rbNPCMax_CheckedChanged(object sender, EventArgs e)         { Properties.Settings.Default.TextureRandomizeNPC        = RandomizeNPC; }
+
+        private void rbPlayHeadsType_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TextureRandomizePlayHeads  = RandomizePlayHeads; }
+        private void rbPlayHeadsMax_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.TextureRandomizePlayHeads  = RandomizePlayHeads; }
+
+        private void rbPlayBodiesType_CheckedChanged(object sender, EventArgs e) { Properties.Settings.Default.TextureRandomizePlayBodies = RandomizePlayBodies; }
+        private void rbPlayBodiesMax_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TextureRandomizePlayBodies = RandomizePlayBodies; }
+
+        private void rbPlaceablesType_CheckedChanged(object sender, EventArgs e) { Properties.Settings.Default.TextureRandomizePlaceables = RandomizePlaceables; }
+        private void rbPlaceablesMax_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TextureRandomizePlaceables = RandomizePlaceables; }
+
+        private void rbPartyType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.TextureRandomizeParty      = RandomizeParty; }
+        private void rbPartyMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.TextureRandomizeParty      = RandomizeParty; }
+
+        private void rbStuntType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.TextureRandomizeStunt      = RandomizeStunt; }
+        private void rbStuntMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.TextureRandomizeStunt      = RandomizeStunt; }
+
+        private void rbVehiclesType_CheckedChanged(object sender, EventArgs e)   { Properties.Settings.Default.TextureRandomizeVehicles   = RandomizeVehicles; }
+        private void rbVehiclesMax_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.TextureRandomizeVehicles   = RandomizeVehicles; }
+
+        private void rbWeaponsType_CheckedChanged(object sender, EventArgs e)    { Properties.Settings.Default.TextureRandomizeWeapons    = RandomizeWeapons; }
+        private void rbWeaponsMax_CheckedChanged(object sender, EventArgs e)     { Properties.Settings.Default.TextureRandomizeWeapons    = RandomizeWeapons; }
+
+        private void rbOtherType_CheckedChanged(object sender, EventArgs e)      { Properties.Settings.Default.TextureRandomizeOther      = RandomizeOther; }
+        private void rbOtherMax_CheckedChanged(object sender, EventArgs e)       { Properties.Settings.Default.TextureRandomizeOther      = RandomizeOther; }
+
+        private void rbTextHigh_CheckedChanged(object sender, EventArgs e) { Properties.Settings.Default.TexturePack = TexturePack.HighQuality; }
+        private void rbTextMed_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TexturePack = TexturePack.MedQuality; }
+        private void rbTextLow_CheckedChanged(object sender, EventArgs e)  { Properties.Settings.Default.TexturePack = TexturePack.LowQuality; }
+
+        // Form event handlers
         private void TextureForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.TextureRandomizeCubeMaps = (int)RandomizeCubeMaps;
-            Properties.Settings.Default.TextureRandomizeCreatures = (int)RandomizeCreatures;
-            Properties.Settings.Default.TextureRandomizeEffects = (int)RandomizeEffects;
-            Properties.Settings.Default.TextureRandomizeItems = (int)RandomizeItems;
-            Properties.Settings.Default.TextureRandomizePlanetary = (int)RandomizePlanetary;
-            Properties.Settings.Default.TextureRandomizeNPC = (int)RandomizeNPC;
-            Properties.Settings.Default.TextureRandomizePlayHeads = (int)RandomizePlayHeads;
-            Properties.Settings.Default.TextureRandomizePlayBodies = (int)RandomizePlayBodies;
-            Properties.Settings.Default.TextureRandomizePlaceables = (int)RandomizePlaceables;
-            Properties.Settings.Default.TextureRandomizeParty = (int)RandomizeParty;
-            Properties.Settings.Default.TextureRandomizeStunt = (int)RandomizeStunt;
-            Properties.Settings.Default.TextureRandomizeVehicles = (int)RandomizeVehicles;
-            Properties.Settings.Default.TextureRandomizeWeapons = (int)RandomizeWeapons;
-            Properties.Settings.Default.TextureRandomizeOther = (int)RandomizeOther;
-
-            if (rbTextHigh.Checked) { Properties.Settings.Default.TexturePack = 0; }
-            if (rbTextMed.Checked) { Properties.Settings.Default.TexturePack = 1; }
-            if (rbTextLow.Checked) { Properties.Settings.Default.TexturePack = 2; }
-
             Properties.Settings.Default.Save();
         }
 
+        // Toggle all button event handlers
         private void bToggleAll_Click(object sender, EventArgs e)
         {
             bool CheckAllBoxes = false;

--- a/kotor Randomizer 2/Forms/TextureForm.resx
+++ b/kotor Randomizer 2/Forms/TextureForm.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="TexturesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="TexturesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="label2.Text" xml:space="preserve">
     <value>Notice:
 The stability of this feature is still questionable. If you recieve any pop-ups or warnings about "invalid bumpmaps", please contact Lane Dibello with the texture name, so he can omit it from randomization. If you encounter issues mid-run, change your quality settings.

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -89,6 +89,20 @@ namespace kotor_Randomizer_2
         MatchSimLengthStrings = 0x10, // 0b00010000
     }
 
+    [Serializable]
+    public enum TexturePack
+    {
+        /// <summary> High Quality </summary>
+        [Description("High Quality")]
+        HighQuality = 0,
+        /// <summary> Medium Quality </summary>
+        [Description("Medium Quality")]
+        MedQuality = 1,
+        /// <summary> Low Quality </summary>
+        [Description("Low Quality")]
+        LowQuality = 2,
+    }
+
     public class Globals
     {
         #region Constants

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -308,6 +308,21 @@ namespace kotor_Randomizer_2
             "ptar_sbpasscrd", "ptar_sitharmor", "tat17_sandperdis", "tat18_dragonprl",
             "w_blhvy001", "w_bstrcrbn", "w_lghtsbr001", "w_null" };
 
+
+        /// <summary>
+        /// Bound list of items to be omitted from randomization. This is necessary because certain items can result in soft locks if randomized.
+        /// </summary>
+        public static readonly List<string> DEFAULT_OMIT_ITEMS = new List<string>()
+        {
+            "g_i_collarlgt001",     // (broken item)
+            "g_i_glowrod01",        // Glow Rod
+            "g_i_torch01",          // (broken item)
+            "ptar_sitharmor",       // Sith Armor
+            "tat17_sandperdis",     // Sand People Disguise
+            "g_i_progspike02",      // Single-Use Programming Spikes
+            "g_i_implant104",       // Stamina Boost Implant
+        };
+
         /// <summary>
         /// All modules in the game
         /// </summary>

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -155,15 +155,15 @@ namespace kotor_Randomizer_2
                         if (new string(br.ReadChars(4)) != "SOUN") { throw new IOException("Sound Randomization is Active, but no such preset data is found. Is the file corrupt?"); }
 
                         // Rando Levels
-                        Properties.Settings.Default.RandomizeAreaMusic = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeBattleMusic = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeAmbientNoise = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeCutsceneNoise = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeNpcSounds = br.ReadInt32();
-                        Properties.Settings.Default.RandomizePartySounds = br.ReadInt32();
+                        Properties.Settings.Default.RandomizeAreaMusic     = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeBattleMusic   = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeAmbientNoise  = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeCutsceneNoise = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeNpcSounds     = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizePartySounds   = (RandomizationLevel)br.ReadInt32();
 
                         // Bools
-                        Properties.Settings.Default.RemoveDmcaMusic = br.ReadBoolean();
+                        Properties.Settings.Default.RemoveDmcaMusic      = br.ReadBoolean();
                         Properties.Settings.Default.MixNpcAndPartySounds = br.ReadBoolean();
                     }
                     #endregion
@@ -393,12 +393,12 @@ namespace kotor_Randomizer_2
                 {
                     bw.Write("SOUN".ToCharArray());
 
-                    bw.Write(Properties.Settings.Default.RandomizeAreaMusic);
-                    bw.Write(Properties.Settings.Default.RandomizeBattleMusic);
-                    bw.Write(Properties.Settings.Default.RandomizeAmbientNoise);
-                    bw.Write(Properties.Settings.Default.RandomizeCutsceneNoise);
-                    bw.Write(Properties.Settings.Default.RandomizeNpcSounds);
-                    bw.Write(Properties.Settings.Default.RandomizePartySounds);
+                    bw.Write((int)Properties.Settings.Default.RandomizeAreaMusic);
+                    bw.Write((int)Properties.Settings.Default.RandomizeBattleMusic);
+                    bw.Write((int)Properties.Settings.Default.RandomizeAmbientNoise);
+                    bw.Write((int)Properties.Settings.Default.RandomizeCutsceneNoise);
+                    bw.Write((int)Properties.Settings.Default.RandomizeNpcSounds);
+                    bw.Write((int)Properties.Settings.Default.RandomizePartySounds);
 
                     bw.Write(Properties.Settings.Default.RemoveDmcaMusic);
                     bw.Write(Properties.Settings.Default.MixNpcAndPartySounds);

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -187,23 +187,23 @@ namespace kotor_Randomizer_2
                         if (new string(br.ReadChars(4)) != "TEXU") { throw new IOException("Texture Randomization is Active, but no such preset data is found. Is the file corrupt?"); }
 
                         // Settings
-                        Properties.Settings.Default.TextureRandomizeCubeMaps = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeCreatures = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeEffects = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeItems = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizePlanetary = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeNPC = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizePlayHeads = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizePlayBodies = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizePlaceables = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeParty = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeStunt = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeVehicles = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeWeapons = br.ReadInt32();
-                        Properties.Settings.Default.TextureRandomizeOther = br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeCubeMaps   = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeCreatures  = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeEffects    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeItems      = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizePlanetary  = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeNPC        = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizePlayHeads  = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizePlayBodies = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizePlaceables = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeParty      = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeStunt      = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeVehicles   = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeWeapons    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.TextureRandomizeOther      = (RandomizationLevel)br.ReadInt32();
 
                         // Texture Pack
-                        Properties.Settings.Default.TexturePack = br.ReadInt32();
+                        Properties.Settings.Default.TexturePack = (TexturePack)br.ReadInt32();
                     }
                     #endregion
                     #region 2DAs
@@ -420,22 +420,22 @@ namespace kotor_Randomizer_2
                 {
                     bw.Write("TEXU".ToCharArray());
 
-                    bw.Write(Properties.Settings.Default.TextureRandomizeCubeMaps);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeCreatures);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeEffects);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeItems);
-                    bw.Write(Properties.Settings.Default.TextureRandomizePlanetary);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeNPC);
-                    bw.Write(Properties.Settings.Default.TextureRandomizePlayHeads);
-                    bw.Write(Properties.Settings.Default.TextureRandomizePlayBodies);
-                    bw.Write(Properties.Settings.Default.TextureRandomizePlaceables);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeParty);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeStunt);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeVehicles);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeWeapons);
-                    bw.Write(Properties.Settings.Default.TextureRandomizeOther);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeCubeMaps);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeCreatures);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeEffects);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeItems);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizePlanetary);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeNPC);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizePlayHeads);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizePlayBodies);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizePlaceables);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeParty);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeStunt);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeVehicles);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeWeapons);
+                    bw.Write((int)Properties.Settings.Default.TextureRandomizeOther);
 
-                    bw.Write(Properties.Settings.Default.TexturePack);
+                    bw.Write((int)Properties.Settings.Default.TexturePack);
 
                 }
                 #endregion

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -112,24 +112,24 @@ namespace kotor_Randomizer_2
                         if (new string(br.ReadChars(4)) != "ITEM") { throw new IOException("Item Randomization is Active, but no such preset data is found. Is the file corrupt?"); }
 
                         // Load in randolevels
-                        Properties.Settings.Default.RandomizeArmor = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeStims = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeBelts = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeVarious = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeHides = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeArmbands = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeDroid = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeGloves = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeImplants = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeMask = br.ReadInt32();
-                        Properties.Settings.Default.RandomizePaz = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeMines = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeUpgrade = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeBlasters = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeCreature = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeLightsabers = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeGrenades = br.ReadInt32();
-                        Properties.Settings.Default.RandomizeMelee = br.ReadInt32();
+                        Properties.Settings.Default.RandomizeArmor       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeStims       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeBelts       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeVarious     = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeHides       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeArmbands    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeDroid       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeGloves      = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeImplants    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeMask        = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizePaz         = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeMines       = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeUpgrade     = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeBlasters    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeCreature    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeLightsabers = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeGrenades    = (RandomizationLevel)br.ReadInt32();
+                        Properties.Settings.Default.RandomizeMelee       = (RandomizationLevel)br.ReadInt32();
 
                         // Load Omit Items
                         Globals.OmitItems.Clear();
@@ -361,24 +361,24 @@ namespace kotor_Randomizer_2
                 {
                     bw.Write("ITEM".ToCharArray());
 
-                    bw.Write(Properties.Settings.Default.RandomizeArmor);
-                    bw.Write(Properties.Settings.Default.RandomizeStims);
-                    bw.Write(Properties.Settings.Default.RandomizeBelts);
-                    bw.Write(Properties.Settings.Default.RandomizeVarious);
-                    bw.Write(Properties.Settings.Default.RandomizeHides);
-                    bw.Write(Properties.Settings.Default.RandomizeArmbands);
-                    bw.Write(Properties.Settings.Default.RandomizeDroid);
-                    bw.Write(Properties.Settings.Default.RandomizeGloves);
-                    bw.Write(Properties.Settings.Default.RandomizeImplants);
-                    bw.Write(Properties.Settings.Default.RandomizeMask);
-                    bw.Write(Properties.Settings.Default.RandomizePaz);
-                    bw.Write(Properties.Settings.Default.RandomizeMines);
-                    bw.Write(Properties.Settings.Default.RandomizeUpgrade);
-                    bw.Write(Properties.Settings.Default.RandomizeBlasters);
-                    bw.Write(Properties.Settings.Default.RandomizeCreature);
-                    bw.Write(Properties.Settings.Default.RandomizeLightsabers);
-                    bw.Write(Properties.Settings.Default.RandomizeGrenades);
-                    bw.Write(Properties.Settings.Default.RandomizeMelee);
+                    bw.Write((int)Properties.Settings.Default.RandomizeArmor);
+                    bw.Write((int)Properties.Settings.Default.RandomizeStims);
+                    bw.Write((int)Properties.Settings.Default.RandomizeBelts);
+                    bw.Write((int)Properties.Settings.Default.RandomizeVarious);
+                    bw.Write((int)Properties.Settings.Default.RandomizeHides);
+                    bw.Write((int)Properties.Settings.Default.RandomizeArmbands);
+                    bw.Write((int)Properties.Settings.Default.RandomizeDroid);
+                    bw.Write((int)Properties.Settings.Default.RandomizeGloves);
+                    bw.Write((int)Properties.Settings.Default.RandomizeImplants);
+                    bw.Write((int)Properties.Settings.Default.RandomizeMask);
+                    bw.Write((int)Properties.Settings.Default.RandomizePaz);
+                    bw.Write((int)Properties.Settings.Default.RandomizeMines);
+                    bw.Write((int)Properties.Settings.Default.RandomizeUpgrade);
+                    bw.Write((int)Properties.Settings.Default.RandomizeBlasters);
+                    bw.Write((int)Properties.Settings.Default.RandomizeCreature);
+                    bw.Write((int)Properties.Settings.Default.RandomizeLightsabers);
+                    bw.Write((int)Properties.Settings.Default.RandomizeGrenades);
+                    bw.Write((int)Properties.Settings.Default.RandomizeMelee);
 
                     foreach (string st in Globals.OmitItems)
                     {

--- a/kotor Randomizer 2/Properties/Resources.Designer.cs
+++ b/kotor Randomizer 2/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace kotor_Randomizer_2.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -155,6 +155,15 @@ namespace kotor_Randomizer_2.Properties {
         internal static string GeneralHelp {
             get {
                 return ResourceManager.GetString("GeneralHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Generate Spoiler Logs.
+        /// </summary>
+        internal static string GenerateSpoilerLogs {
+            get {
+                return ResourceManager.GetString("GenerateSpoilerLogs", resourceCulture);
             }
         }
         
@@ -487,6 +496,15 @@ namespace kotor_Randomizer_2.Properties {
         internal static string RandoHelp {
             get {
                 return ResourceManager.GetString("RandoHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Randomization Error.
+        /// </summary>
+        internal static string RandomizationError {
+            get {
+                return ResourceManager.GetString("RandomizationError", resourceCulture);
             }
         }
         

--- a/kotor Randomizer 2/Properties/Resources.resx
+++ b/kotor Randomizer 2/Properties/Resources.resx
@@ -337,4 +337,10 @@
   <data name="k_ren_visionland" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\k_ren_visionland.ncs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="GenerateSpoilerLogs" xml:space="preserve">
+    <value>Generate Spoiler Logs</value>
+  </data>
+  <data name="RandomizationError" xml:space="preserve">
+    <value>Randomization Error</value>
+  </data>
 </root>

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -61,10 +61,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeAreaMusic {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeAreaMusic {
             get {
-                return ((int)(this["RandomizeAreaMusic"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeAreaMusic"]));
             }
             set {
                 this["RandomizeAreaMusic"] = value;
@@ -73,10 +73,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeAmbientNoise {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeAmbientNoise {
             get {
-                return ((int)(this["RandomizeAmbientNoise"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeAmbientNoise"]));
             }
             set {
                 this["RandomizeAmbientNoise"] = value;
@@ -85,10 +85,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeCutsceneNoise {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeCutsceneNoise {
             get {
-                return ((int)(this["RandomizeCutsceneNoise"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeCutsceneNoise"]));
             }
             set {
                 this["RandomizeCutsceneNoise"] = value;
@@ -97,10 +97,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeNpcSounds {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeNpcSounds {
             get {
-                return ((int)(this["RandomizeNpcSounds"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeNpcSounds"]));
             }
             set {
                 this["RandomizeNpcSounds"] = value;
@@ -109,10 +109,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizePartySounds {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizePartySounds {
             get {
-                return ((int)(this["RandomizePartySounds"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizePartySounds"]));
             }
             set {
                 this["RandomizePartySounds"] = value;
@@ -121,10 +121,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeBattleMusic {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeBattleMusic {
             get {
-                return ((int)(this["RandomizeBattleMusic"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeBattleMusic"]));
             }
             set {
                 this["RandomizeBattleMusic"] = value;

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -517,10 +517,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeCubeMaps {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeCubeMaps {
             get {
-                return ((int)(this["TextureRandomizeCubeMaps"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeCubeMaps"]));
             }
             set {
                 this["TextureRandomizeCubeMaps"] = value;
@@ -529,10 +529,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeCreatures {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeCreatures {
             get {
-                return ((int)(this["TextureRandomizeCreatures"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeCreatures"]));
             }
             set {
                 this["TextureRandomizeCreatures"] = value;
@@ -541,10 +541,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeEffects {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeEffects {
             get {
-                return ((int)(this["TextureRandomizeEffects"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeEffects"]));
             }
             set {
                 this["TextureRandomizeEffects"] = value;
@@ -553,10 +553,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeItems {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeItems {
             get {
-                return ((int)(this["TextureRandomizeItems"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeItems"]));
             }
             set {
                 this["TextureRandomizeItems"] = value;
@@ -565,10 +565,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizePlanetary {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizePlanetary {
             get {
-                return ((int)(this["TextureRandomizePlanetary"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizePlanetary"]));
             }
             set {
                 this["TextureRandomizePlanetary"] = value;
@@ -577,10 +577,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeNPC {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeNPC {
             get {
-                return ((int)(this["TextureRandomizeNPC"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeNPC"]));
             }
             set {
                 this["TextureRandomizeNPC"] = value;
@@ -589,10 +589,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizePlayHeads {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizePlayHeads {
             get {
-                return ((int)(this["TextureRandomizePlayHeads"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizePlayHeads"]));
             }
             set {
                 this["TextureRandomizePlayHeads"] = value;
@@ -601,10 +601,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizePlayBodies {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizePlayBodies {
             get {
-                return ((int)(this["TextureRandomizePlayBodies"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizePlayBodies"]));
             }
             set {
                 this["TextureRandomizePlayBodies"] = value;
@@ -613,10 +613,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizePlaceables {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizePlaceables {
             get {
-                return ((int)(this["TextureRandomizePlaceables"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizePlaceables"]));
             }
             set {
                 this["TextureRandomizePlaceables"] = value;
@@ -625,10 +625,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeParty {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeParty {
             get {
-                return ((int)(this["TextureRandomizeParty"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeParty"]));
             }
             set {
                 this["TextureRandomizeParty"] = value;
@@ -637,10 +637,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeStunt {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeStunt {
             get {
-                return ((int)(this["TextureRandomizeStunt"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeStunt"]));
             }
             set {
                 this["TextureRandomizeStunt"] = value;
@@ -649,10 +649,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeVehicles {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeVehicles {
             get {
-                return ((int)(this["TextureRandomizeVehicles"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeVehicles"]));
             }
             set {
                 this["TextureRandomizeVehicles"] = value;
@@ -661,10 +661,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeWeapons {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeWeapons {
             get {
-                return ((int)(this["TextureRandomizeWeapons"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeWeapons"]));
             }
             set {
                 this["TextureRandomizeWeapons"] = value;
@@ -673,10 +673,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TextureRandomizeOther {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel TextureRandomizeOther {
             get {
-                return ((int)(this["TextureRandomizeOther"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["TextureRandomizeOther"]));
             }
             set {
                 this["TextureRandomizeOther"] = value;
@@ -760,10 +760,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int TexturePack {
+        [global::System.Configuration.DefaultSettingValueAttribute("HighQuality")]
+        public global::kotor_Randomizer_2.TexturePack TexturePack {
             get {
-                return ((int)(this["TexturePack"]));
+                return ((global::kotor_Randomizer_2.TexturePack)(this["TexturePack"]));
             }
             set {
                 this["TexturePack"] = value;

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -265,10 +265,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeArmor {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeArmor {
             get {
-                return ((int)(this["RandomizeArmor"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeArmor"]));
             }
             set {
                 this["RandomizeArmor"] = value;
@@ -277,10 +277,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeStims {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeStims {
             get {
-                return ((int)(this["RandomizeStims"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeStims"]));
             }
             set {
                 this["RandomizeStims"] = value;
@@ -289,10 +289,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeBelts {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeBelts {
             get {
-                return ((int)(this["RandomizeBelts"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeBelts"]));
             }
             set {
                 this["RandomizeBelts"] = value;
@@ -301,10 +301,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeVarious {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeVarious {
             get {
-                return ((int)(this["RandomizeVarious"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeVarious"]));
             }
             set {
                 this["RandomizeVarious"] = value;
@@ -313,10 +313,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeHides {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeHides {
             get {
-                return ((int)(this["RandomizeHides"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeHides"]));
             }
             set {
                 this["RandomizeHides"] = value;
@@ -325,10 +325,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeArmbands {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeArmbands {
             get {
-                return ((int)(this["RandomizeArmbands"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeArmbands"]));
             }
             set {
                 this["RandomizeArmbands"] = value;
@@ -337,10 +337,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeDroid {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeDroid {
             get {
-                return ((int)(this["RandomizeDroid"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeDroid"]));
             }
             set {
                 this["RandomizeDroid"] = value;
@@ -349,10 +349,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeGloves {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeGloves {
             get {
-                return ((int)(this["RandomizeGloves"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeGloves"]));
             }
             set {
                 this["RandomizeGloves"] = value;
@@ -361,10 +361,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeImplants {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeImplants {
             get {
-                return ((int)(this["RandomizeImplants"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeImplants"]));
             }
             set {
                 this["RandomizeImplants"] = value;
@@ -373,10 +373,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeMask {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeMask {
             get {
-                return ((int)(this["RandomizeMask"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeMask"]));
             }
             set {
                 this["RandomizeMask"] = value;
@@ -385,10 +385,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizePaz {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizePaz {
             get {
-                return ((int)(this["RandomizePaz"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizePaz"]));
             }
             set {
                 this["RandomizePaz"] = value;
@@ -397,10 +397,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeMines {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeMines {
             get {
-                return ((int)(this["RandomizeMines"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeMines"]));
             }
             set {
                 this["RandomizeMines"] = value;
@@ -409,10 +409,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeUpgrade {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeUpgrade {
             get {
-                return ((int)(this["RandomizeUpgrade"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeUpgrade"]));
             }
             set {
                 this["RandomizeUpgrade"] = value;
@@ -421,10 +421,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeBlasters {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeBlasters {
             get {
-                return ((int)(this["RandomizeBlasters"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeBlasters"]));
             }
             set {
                 this["RandomizeBlasters"] = value;
@@ -433,10 +433,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeCreature {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeCreature {
             get {
-                return ((int)(this["RandomizeCreature"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeCreature"]));
             }
             set {
                 this["RandomizeCreature"] = value;
@@ -445,10 +445,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeLightsabers {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeLightsabers {
             get {
-                return ((int)(this["RandomizeLightsabers"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeLightsabers"]));
             }
             set {
                 this["RandomizeLightsabers"] = value;
@@ -457,10 +457,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeGrenades {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeGrenades {
             get {
-                return ((int)(this["RandomizeGrenades"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeGrenades"]));
             }
             set {
                 this["RandomizeGrenades"] = value;
@@ -469,10 +469,10 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int RandomizeMelee {
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::kotor_Randomizer_2.RandomizationLevel RandomizeMelee {
             get {
-                return ((int)(this["RandomizeMelee"]));
+                return ((global::kotor_Randomizer_2.RandomizationLevel)(this["RandomizeMelee"]));
             }
             set {
                 this["RandomizeMelee"] = value;

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -62,59 +62,59 @@
     <Setting Name="DoRandomization_Other" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="RandomizeArmor" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeArmor" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeStims" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeStims" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeBelts" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeBelts" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeVarious" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeVarious" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeHides" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeHides" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeArmbands" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeArmbands" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeDroid" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeDroid" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeGloves" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeGloves" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeImplants" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeImplants" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeMask" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeMask" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizePaz" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizePaz" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeMines" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeMines" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeUpgrade" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeUpgrade" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeBlasters" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeBlasters" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeCreature" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeCreature" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeLightsabers" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeLightsabers" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeGrenades" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeGrenades" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeMelee" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeMelee" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
     <Setting Name="RandomizeDoorModels" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -125,47 +125,47 @@
     <Setting Name="RandomizePlaceModels" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="TextureRandomizeCubeMaps" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeCubeMaps" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeCreatures" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeCreatures" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeEffects" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeEffects" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeItems" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeItems" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizePlanetary" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizePlanetary" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeNPC" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeNPC" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizePlayHeads" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizePlayHeads" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizePlayBodies" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizePlayBodies" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizePlaceables" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizePlaceables" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeParty" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeParty" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeStunt" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeStunt" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeVehicles" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeVehicles" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeWeapons" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeWeapons" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="TextureRandomizeOther" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TextureRandomizeOther" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
     <Setting Name="KotorIsRandomized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
@@ -188,8 +188,8 @@
     <Setting Name="RandomizeNameGen" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="TexturePack" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="TexturePack" Type="kotor_Randomizer_2.TexturePack" Scope="User">
+      <Value Profile="(Default)">HighQuality</Value>
     </Setting>
     <Setting Name="RandomizePazaakDecks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -11,23 +11,23 @@
     <Setting Name="MixNpcAndPartySounds" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="RandomizeAreaMusic" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeAreaMusic" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeAmbientNoise" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeAmbientNoise" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeCutsceneNoise" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeCutsceneNoise" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeNpcSounds" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeNpcSounds" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizePartySounds" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizePartySounds" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="RandomizeBattleMusic" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+    <Setting Name="RandomizeBattleMusic" Type="kotor_Randomizer_2.RandomizationLevel" Scope="User">
+      <Value Profile="(Default)">None</Value>
     </Setting>
     <Setting Name="ModulesInitialized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -48,7 +48,7 @@ namespace kotor_Randomizer_2
             HandleCategory(k, UpgradeRegs, Properties.Settings.Default.RandomizeUpgrade);
 
             //handle Various
-            switch ((RandomizationLevel)Properties.Settings.Default.RandomizeVarious)
+            switch (Properties.Settings.Default.RandomizeVarious)
             {
                 default:
                 case RandomizationLevel.None:
@@ -90,9 +90,9 @@ namespace kotor_Randomizer_2
             k.WriteToFile(paths.chitin);
         }
 
-        private static void HandleCategory(KEY k, List<Regex> r, int randomizationLevel)
+        private static void HandleCategory(KEY k, List<Regex> r, RandomizationLevel randomizationLevel)
         {
-            switch ((RandomizationLevel)randomizationLevel)
+            switch (randomizationLevel)
             {
                 case RandomizationLevel.None:
                 default:
@@ -165,24 +165,24 @@ namespace kotor_Randomizer_2
                 sw.WriteLine();
 
                 sw.WriteLine("Item Type,Rando Level");
-                sw.WriteLine($"Armbands,{(RandomizationLevel)Properties.Settings.Default.RandomizeArmbands}");
-                sw.WriteLine($"Armor,{(RandomizationLevel)Properties.Settings.Default.RandomizeArmor}");
-                sw.WriteLine($"Belts,{(RandomizationLevel)Properties.Settings.Default.RandomizeBelts}");
-                sw.WriteLine($"Blasters,{(RandomizationLevel)Properties.Settings.Default.RandomizeBlasters}");
-                sw.WriteLine($"Creature Hides,{(RandomizationLevel)Properties.Settings.Default.RandomizeHides}");
-                sw.WriteLine($"Creature Weapons,{(RandomizationLevel)Properties.Settings.Default.RandomizeCreature}");
-                sw.WriteLine($"Droid Equipment,{(RandomizationLevel)Properties.Settings.Default.RandomizeDroid}");
-                sw.WriteLine($"Gauntlets,{(RandomizationLevel)Properties.Settings.Default.RandomizeGloves}");
-                sw.WriteLine($"Grenades,{(RandomizationLevel)Properties.Settings.Default.RandomizeGrenades}");
-                sw.WriteLine($"Implants,{(RandomizationLevel)Properties.Settings.Default.RandomizeImplants}");
-                sw.WriteLine($"Lightsabers,{(RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers}");
-                sw.WriteLine($"Masks,{(RandomizationLevel)Properties.Settings.Default.RandomizeMask}");
-                sw.WriteLine($"Melee Weapons,{(RandomizationLevel)Properties.Settings.Default.RandomizeMelee}");
-                sw.WriteLine($"Mines,{(RandomizationLevel)Properties.Settings.Default.RandomizeMines}");
-                sw.WriteLine($"Pazaak Cards,{(RandomizationLevel)Properties.Settings.Default.RandomizePaz}");
-                sw.WriteLine($"Stims/Medpacs,{(RandomizationLevel)Properties.Settings.Default.RandomizeStims}");
-                sw.WriteLine($"Upgrades/Crystals,{(RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade}");
-                sw.WriteLine($"Various,{(RandomizationLevel)Properties.Settings.Default.RandomizeVarious}");
+                sw.WriteLine($"Armbands,{Properties.Settings.Default.RandomizeArmbands}");
+                sw.WriteLine($"Armor,{Properties.Settings.Default.RandomizeArmor}");
+                sw.WriteLine($"Belts,{Properties.Settings.Default.RandomizeBelts}");
+                sw.WriteLine($"Blasters,{Properties.Settings.Default.RandomizeBlasters}");
+                sw.WriteLine($"Creature Hides,{Properties.Settings.Default.RandomizeHides}");
+                sw.WriteLine($"Creature Weapons,{Properties.Settings.Default.RandomizeCreature}");
+                sw.WriteLine($"Droid Equipment,{Properties.Settings.Default.RandomizeDroid}");
+                sw.WriteLine($"Gauntlets,{Properties.Settings.Default.RandomizeGloves}");
+                sw.WriteLine($"Grenades,{Properties.Settings.Default.RandomizeGrenades}");
+                sw.WriteLine($"Implants,{Properties.Settings.Default.RandomizeImplants}");
+                sw.WriteLine($"Lightsabers,{Properties.Settings.Default.RandomizeLightsabers}");
+                sw.WriteLine($"Masks,{Properties.Settings.Default.RandomizeMask}");
+                sw.WriteLine($"Melee Weapons,{Properties.Settings.Default.RandomizeMelee}");
+                sw.WriteLine($"Mines,{Properties.Settings.Default.RandomizeMines}");
+                sw.WriteLine($"Pazaak Cards,{Properties.Settings.Default.RandomizePaz}");
+                sw.WriteLine($"Stims/Medpacs,{Properties.Settings.Default.RandomizeStims}");
+                sw.WriteLine($"Upgrades/Crystals,{Properties.Settings.Default.RandomizeUpgrade}");
+                sw.WriteLine($"Various,{Properties.Settings.Default.RandomizeVarious}");
                 sw.WriteLine();
 
                 sw.WriteLine("Omitted Items");
@@ -238,24 +238,24 @@ namespace kotor_Randomizer_2
 
             var settings = new List<Tuple<string, string>>()
             {
-                new Tuple<string, string>("Armbands", ((RandomizationLevel)Properties.Settings.Default.RandomizeArmbands).ToString()),
-                new Tuple<string, string>("Armor", ((RandomizationLevel)Properties.Settings.Default.RandomizeArmor).ToString()),
-                new Tuple<string, string>("Belts", ((RandomizationLevel)Properties.Settings.Default.RandomizeBelts).ToString()),
-                new Tuple<string, string>("Blasters", ((RandomizationLevel)Properties.Settings.Default.RandomizeBlasters).ToString()),
-                new Tuple<string, string>("Creature Hides", ((RandomizationLevel)Properties.Settings.Default.RandomizeHides).ToString()),
-                new Tuple<string, string>("Creature Weapons", ((RandomizationLevel)Properties.Settings.Default.RandomizeCreature).ToString()),
-                new Tuple<string, string>("Droid Equipment", ((RandomizationLevel)Properties.Settings.Default.RandomizeDroid).ToString()),
-                new Tuple<string, string>("Gauntlets", ((RandomizationLevel)Properties.Settings.Default.RandomizeGloves).ToString()),
-                new Tuple<string, string>("Grenades", ((RandomizationLevel)Properties.Settings.Default.RandomizeGrenades).ToString()),
-                new Tuple<string, string>("Implants", ((RandomizationLevel)Properties.Settings.Default.RandomizeImplants).ToString()),
-                new Tuple<string, string>("Lightsabers", ((RandomizationLevel)Properties.Settings.Default.RandomizeLightsabers).ToString()),
-                new Tuple<string, string>("Masks", ((RandomizationLevel)Properties.Settings.Default.RandomizeMask).ToString()),
-                new Tuple<string, string>("Melee Weapons", ((RandomizationLevel)Properties.Settings.Default.RandomizeMelee).ToString()),
-                new Tuple<string, string>("Mines", ((RandomizationLevel)Properties.Settings.Default.RandomizeMines).ToString()),
-                new Tuple<string, string>("Pazaak Cards", ((RandomizationLevel)Properties.Settings.Default.RandomizePaz).ToString()),
-                new Tuple<string, string>("Stims/Medpacs", ((RandomizationLevel)Properties.Settings.Default.RandomizeStims).ToString()),
-                new Tuple<string, string>("Upgrades/Crystals", ((RandomizationLevel)Properties.Settings.Default.RandomizeUpgrade).ToString()),
-                new Tuple<string, string>("Various", ((RandomizationLevel)Properties.Settings.Default.RandomizeVarious).ToString()),
+                new Tuple<string, string>("Armbands", Properties.Settings.Default.RandomizeArmbands.ToString()),
+                new Tuple<string, string>("Armor", Properties.Settings.Default.RandomizeArmor.ToString()),
+                new Tuple<string, string>("Belts", Properties.Settings.Default.RandomizeBelts.ToString()),
+                new Tuple<string, string>("Blasters", Properties.Settings.Default.RandomizeBlasters.ToString()),
+                new Tuple<string, string>("Creature Hides", Properties.Settings.Default.RandomizeHides.ToString()),
+                new Tuple<string, string>("Creature Weapons", Properties.Settings.Default.RandomizeCreature.ToString()),
+                new Tuple<string, string>("Droid Equipment", Properties.Settings.Default.RandomizeDroid.ToString()),
+                new Tuple<string, string>("Gauntlets", Properties.Settings.Default.RandomizeGloves.ToString()),
+                new Tuple<string, string>("Grenades", Properties.Settings.Default.RandomizeGrenades.ToString()),
+                new Tuple<string, string>("Implants", Properties.Settings.Default.RandomizeImplants.ToString()),
+                new Tuple<string, string>("Lightsabers", Properties.Settings.Default.RandomizeLightsabers.ToString()),
+                new Tuple<string, string>("Masks", Properties.Settings.Default.RandomizeMask.ToString()),
+                new Tuple<string, string>("Melee Weapons", Properties.Settings.Default.RandomizeMelee.ToString()),
+                new Tuple<string, string>("Mines", Properties.Settings.Default.RandomizeMines.ToString()),
+                new Tuple<string, string>("Pazaak Cards", Properties.Settings.Default.RandomizePaz.ToString()),
+                new Tuple<string, string>("Stims/Medpacs", Properties.Settings.Default.RandomizeStims.ToString()),
+                new Tuple<string, string>("Upgrades/Crystals", Properties.Settings.Default.RandomizeUpgrade.ToString()),
+                new Tuple<string, string>("Various", Properties.Settings.Default.RandomizeVarious.ToString()),
             };
 
             foreach (var setting in settings)

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -20,6 +20,11 @@ namespace kotor_Randomizer_2
             InitializeComponent();
         }
 
+        public bool IsInProgress
+        {
+            get { return bwRandomizing.IsBusy || bwUnrandomizing.IsBusy; }
+        }
+
         #region Private Properties
 
         private string curr_task = "";

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -39,7 +39,7 @@ namespace kotor_Randomizer_2
 
             if (ActiveCategories == 0)
             {
-                MessageBox.Show(Properties.Resources.ErrorNoRandomization);
+                MessageBox.Show(Properties.Resources.ErrorNoRandomization, Properties.Resources.RandomizationError);
                 return;
             }
             ActiveCategories++;
@@ -161,7 +161,7 @@ namespace kotor_Randomizer_2
                 catch (Exception e)
                 {
                     // Catch any randomization errors (e.g., reachability failure) and print a message.
-                    MessageBox.Show($"Error encountered during randomization: {Environment.NewLine}{e.Message}", "Randomization Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBox.Show($"Error encountered during randomization: {Environment.NewLine}{e.Message}", Properties.Resources.RandomizationError, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
                 finally
                 {
@@ -192,7 +192,7 @@ namespace kotor_Randomizer_2
         {
             if (!File.Exists(paths.RANDOMIZED_LOG))
             {
-                MessageBox.Show(Properties.Resources.ErrorNotRandomized);
+                MessageBox.Show(Properties.Resources.ErrorNotRandomized, Properties.Resources.RandomizationError);
                 return;
             }
 
@@ -215,7 +215,7 @@ namespace kotor_Randomizer_2
         {
             if (!File.Exists(paths.RANDOMIZED_LOG))
             {
-                MessageBox.Show(Properties.Resources.ErrorNotRandomized);
+                MessageBox.Show(Properties.Resources.ErrorNotRandomized, Properties.Resources.RandomizationError);
                 return;
             }
 
@@ -267,7 +267,7 @@ namespace kotor_Randomizer_2
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Exception caught while {curr_task}. {e.Message}");
+                MessageBox.Show($"Exception caught while {curr_task}. {e.Message}", Properties.Resources.RandomizationError);
             }
         }
 

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -25,6 +25,17 @@ namespace kotor_Randomizer_2
             get { return bwRandomizing.IsBusy || bwUnrandomizing.IsBusy; }
         }
 
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                const int PARAM_NOCLOSE = 0x200;
+                CreateParams param = base.CreateParams;
+                param.ClassStyle = param.ClassStyle | PARAM_NOCLOSE;
+                return param;
+            }
+        }
+
         #region Private Properties
 
         private string curr_task = "";
@@ -346,7 +357,8 @@ namespace kotor_Randomizer_2
 
         private void bDone_Click(object sender, EventArgs e)
         {
-            Close();
+            // Avoid closing the window if background workers are still running.
+            if (!IsInProgress) Close();
         }
 
         private void bwRandomizing_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/kotor Randomizer 2/Randomization/SoundRando.cs
+++ b/kotor Randomizer 2/Randomization/SoundRando.cs
@@ -39,7 +39,7 @@ namespace kotor_Randomizer_2
                 areaMusic.RemoveAll(f => DmcaAreaMusic.Contains(f.Name));   // Remove DMCA music from the area list.
             }
 
-            switch ((RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic)
+            switch (Properties.Settings.Default.RandomizeAreaMusic)
             {
                 case RandomizationLevel.Max:
                     maxMusic.AddRange(areaMusic);
@@ -67,7 +67,7 @@ namespace kotor_Randomizer_2
                 ambientNoiseSound.AddRange(soundFiles.Where(f => f.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)));
             }
 
-            switch ((RandomizationLevel)Properties.Settings.Default.RandomizeAmbientNoise)
+            switch (Properties.Settings.Default.RandomizeAmbientNoise)
             {
                 case RandomizationLevel.Max:
                     maxMusic.AddRange(ambientNoiseMusic);
@@ -90,7 +90,7 @@ namespace kotor_Randomizer_2
             List<FileInfo> battleMusic = new List<FileInfo>(musicFiles.Where(f => RegexBattleMusic.IsMatch(f.Name)));
             List<FileInfo> battleMusicEnd = new List<FileInfo>(soundFiles.Where(f => RegexBattleMusic.IsMatch(f.Name)));
 
-            switch ((RandomizationLevel)Properties.Settings.Default.RandomizeBattleMusic)
+            switch (Properties.Settings.Default.RandomizeBattleMusic)
             {
                 case RandomizationLevel.Max:
                     maxMusic.AddRange(battleMusic);
@@ -113,7 +113,7 @@ namespace kotor_Randomizer_2
             List<FileInfo> cutsceneNoise = new List<FileInfo>(musicFiles.Where(f => RegexCutscene.IsMatch(f.Name)));
             cutsceneNoise.RemoveAll(f => f.Name.StartsWith("57.")); // Remove specific exception
 
-            switch ((RandomizationLevel)Properties.Settings.Default.RandomizeCutsceneNoise)
+            switch (Properties.Settings.Default.RandomizeCutsceneNoise)
             {
                 case RandomizationLevel.Max:
                     maxMusic.AddRange(cutsceneNoise);
@@ -139,7 +139,7 @@ namespace kotor_Randomizer_2
             //else
             {
                 // Party Sounds (if not mixing)
-                switch ((RandomizationLevel)Properties.Settings.Default.RandomizePartySounds)
+                switch (Properties.Settings.Default.RandomizePartySounds)
                 {
                     case RandomizationLevel.Max:
                         maxSound.AddRange(partySounds);
@@ -330,12 +330,12 @@ namespace kotor_Randomizer_2
                 sw.WriteLine($"Seed,{Properties.Settings.Default.Seed}");
                 sw.WriteLine();
 
-                sw.WriteLine($"Area Music,{(RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic}");
-                sw.WriteLine($"Battle Music,{(RandomizationLevel)Properties.Settings.Default.RandomizeBattleMusic}");
-                sw.WriteLine($"Ambient Noise,{(RandomizationLevel)Properties.Settings.Default.RandomizeAmbientNoise}");
-                sw.WriteLine($"Cutscene Noise,{(RandomizationLevel)Properties.Settings.Default.RandomizeCutsceneNoise}");
-                sw.WriteLine($"NPC Sounds,{(RandomizationLevel)Properties.Settings.Default.RandomizeNpcSounds}");
-                sw.WriteLine($"Party Sounds,{(RandomizationLevel)Properties.Settings.Default.RandomizePartySounds}");
+                sw.WriteLine($"Area Music,{Properties.Settings.Default.RandomizeAreaMusic}");
+                sw.WriteLine($"Battle Music,{Properties.Settings.Default.RandomizeBattleMusic}");
+                sw.WriteLine($"Ambient Noise,{Properties.Settings.Default.RandomizeAmbientNoise}");
+                sw.WriteLine($"Cutscene Noise,{Properties.Settings.Default.RandomizeCutsceneNoise}");
+                sw.WriteLine($"NPC Sounds,{Properties.Settings.Default.RandomizeNpcSounds}");
+                sw.WriteLine($"Party Sounds,{Properties.Settings.Default.RandomizePartySounds}");
                 sw.WriteLine($"Remove DMCA,{Properties.Settings.Default.RemoveDmcaMusic}");
                 sw.WriteLine($"Mix NPC and Party,{Properties.Settings.Default.MixNpcAndPartySounds}");
                 sw.WriteLine();
@@ -394,12 +394,12 @@ namespace kotor_Randomizer_2
 
             var settings = new List<Tuple<string, string>>()
             {
-                new Tuple<string, string>("Area Music", ((RandomizationLevel)Properties.Settings.Default.RandomizeAreaMusic).ToString()),
-                new Tuple<string, string>("Battle Music", ((RandomizationLevel)Properties.Settings.Default.RandomizeBattleMusic).ToString()),
-                new Tuple<string, string>("Ambient Noise", ((RandomizationLevel)Properties.Settings.Default.RandomizeAmbientNoise).ToString()),
-                new Tuple<string, string>("Cutscene Noise", ((RandomizationLevel)Properties.Settings.Default.RandomizeCutsceneNoise).ToString()),
-                new Tuple<string, string>("NPC Sounds", ((RandomizationLevel)Properties.Settings.Default.RandomizeNpcSounds).ToString()),
-                new Tuple<string, string>("Party Sounds", ((RandomizationLevel)Properties.Settings.Default.RandomizePartySounds).ToString()),
+                new Tuple<string, string>("Area Music", Properties.Settings.Default.RandomizeAreaMusic.ToString()),
+                new Tuple<string, string>("Battle Music", Properties.Settings.Default.RandomizeBattleMusic.ToString()),
+                new Tuple<string, string>("Ambient Noise", Properties.Settings.Default.RandomizeAmbientNoise.ToString()),
+                new Tuple<string, string>("Cutscene Noise", Properties.Settings.Default.RandomizeCutsceneNoise.ToString()),
+                new Tuple<string, string>("NPC Sounds", Properties.Settings.Default.RandomizeNpcSounds.ToString()),
+                new Tuple<string, string>("Party Sounds", Properties.Settings.Default.RandomizePartySounds.ToString()),
                 new Tuple<string, string>("Remove DMCA", Properties.Settings.Default.RemoveDmcaMusic.ToString()),
                 new Tuple<string, string>("Mix NPC and Party", Properties.Settings.Default.MixNpcAndPartySounds.ToString()),
                 new Tuple<string, string>("", ""),  // Skip a row.

--- a/kotor Randomizer 2/Randomization/TextureRando.cs
+++ b/kotor Randomizer 2/Randomization/TextureRando.cs
@@ -54,13 +54,13 @@ namespace kotor_Randomizer_2
             switch (Properties.Settings.Default.TexturePack)
             {
                 default:
-                case 0: // High quality
+                case TexturePack.HighQuality:
                     pack_name = "\\swpc_tex_tpa.erf";
                     break;
-                case 1: // Medium quality
+                case TexturePack.MedQuality:
                     pack_name = "\\swpc_tex_tpb.erf";
                     break;
-                case 2: // Low quality
+                case TexturePack.LowQuality:
                     pack_name = "\\swpc_tex_tpc.erf";
                     break;
             }
@@ -74,22 +74,22 @@ namespace kotor_Randomizer_2
             }
 
             // Handle categories.
-            HandleCategory(e, RegexCubeMaps, Properties.Settings.Default.TextureRandomizeCubeMaps);
-            HandleCategory(e, RegexCreatures, Properties.Settings.Default.TextureRandomizeCreatures);
-            HandleCategory(e, RegexEffects, Properties.Settings.Default.TextureRandomizeEffects);
-            HandleCategory(e, RegexItems, Properties.Settings.Default.TextureRandomizeItems);
-            HandleCategory(e, RegexPlanetary, Properties.Settings.Default.TextureRandomizePlanetary);
-            HandleCategory(e, RegexNPC, Properties.Settings.Default.TextureRandomizeNPC);
-            HandleCategory(e, RegexPlayHeads, Properties.Settings.Default.TextureRandomizePlayHeads);
+            HandleCategory(e, RegexCubeMaps,   Properties.Settings.Default.TextureRandomizeCubeMaps);
+            HandleCategory(e, RegexCreatures,  Properties.Settings.Default.TextureRandomizeCreatures);
+            HandleCategory(e, RegexEffects,    Properties.Settings.Default.TextureRandomizeEffects);
+            HandleCategory(e, RegexItems,      Properties.Settings.Default.TextureRandomizeItems);
+            HandleCategory(e, RegexPlanetary,  Properties.Settings.Default.TextureRandomizePlanetary);
+            HandleCategory(e, RegexNPC,        Properties.Settings.Default.TextureRandomizeNPC);
+            HandleCategory(e, RegexPlayHeads,  Properties.Settings.Default.TextureRandomizePlayHeads);
             HandleCategory(e, RegexPlayBodies, Properties.Settings.Default.TextureRandomizePlayBodies);
             HandleCategory(e, RegexPlaceables, Properties.Settings.Default.TextureRandomizePlaceables);
-            HandleCategory(e, RegexParty, Properties.Settings.Default.TextureRandomizeParty);
-            HandleCategory(e, RegexStunt, Properties.Settings.Default.TextureRandomizeStunt);
-            HandleCategory(e, RegexVehicles, Properties.Settings.Default.TextureRandomizeVehicles);
-            HandleCategory(e, RegexWeapons, Properties.Settings.Default.TextureRandomizeWeapons);
+            HandleCategory(e, RegexParty,      Properties.Settings.Default.TextureRandomizeParty);
+            HandleCategory(e, RegexStunt,      Properties.Settings.Default.TextureRandomizeStunt);
+            HandleCategory(e, RegexVehicles,   Properties.Settings.Default.TextureRandomizeVehicles);
+            HandleCategory(e, RegexWeapons,    Properties.Settings.Default.TextureRandomizeWeapons);
 
             // Handle other.
-            switch ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeOther)
+            switch (Properties.Settings.Default.TextureRandomizeOther)
             {
                 default:
                 case RandomizationLevel.None:
@@ -162,9 +162,9 @@ namespace kotor_Randomizer_2
             );
         }
 
-        private static void HandleCategory(ERF e, Regex r, int randomizationlevel)
+        private static void HandleCategory(ERF e, Regex r, RandomizationLevel randomizationlevel)
         {
-            switch ((RandomizationLevel)randomizationlevel)
+            switch (randomizationlevel)
             {
                 default:
                 case RandomizationLevel.None:
@@ -200,23 +200,8 @@ namespace kotor_Randomizer_2
             i++;
 
             // Texture Randomization Settings
-            string texturePack = "";
-            switch (Properties.Settings.Default.TexturePack)
-            {
-                default:
-                case 0:
-                    texturePack = "High Quality";
-                    break;
-                case 1:
-                    texturePack = "Med Quality";
-                    break;
-                case 2:
-                    texturePack = "Low Quality";
-                    break;
-            }
-
             ws.Cell(i, 1).Value = "Texture Pack";
-            ws.Cell(i, 2).Value = texturePack;
+            ws.Cell(i, 2).Value = Properties.Settings.Default.TexturePack.ToDescription();
             ws.Cell(i, 1).Style.Font.Bold = true;
             i += 2;     // Skip a row.
 
@@ -230,20 +215,20 @@ namespace kotor_Randomizer_2
 
             var settings = new List<Tuple<string, string>>()
             {
-                new Tuple<string, string>("Cube Maps", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeCubeMaps).ToString()),
-                new Tuple<string, string>("Creatures", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeCreatures).ToString()),
-                new Tuple<string, string>("Effects", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeEffects).ToString()),
-                new Tuple<string, string>("Items", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeItems).ToString()),
-                new Tuple<string, string>("Planetary", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlanetary).ToString()),
-                new Tuple<string, string>("NPC", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeNPC).ToString()),
-                new Tuple<string, string>("Player Heads", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayHeads).ToString()),
-                new Tuple<string, string>("Player Bodies", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlayBodies).ToString()),
-                new Tuple<string, string>("Placeables", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizePlaceables).ToString()),
-                new Tuple<string, string>("Party", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeParty).ToString()),
-                new Tuple<string, string>("Stunt", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeStunt).ToString()),
-                new Tuple<string, string>("Vehicles", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeVehicles).ToString()),
-                new Tuple<string, string>("Weapons", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeWeapons).ToString()),
-                new Tuple<string, string>("Other", ((RandomizationLevel)Properties.Settings.Default.TextureRandomizeOther).ToString()),
+                new Tuple<string, string>("Cube Maps", Properties.Settings.Default.TextureRandomizeCubeMaps.ToString()),
+                new Tuple<string, string>("Creatures", Properties.Settings.Default.TextureRandomizeCreatures.ToString()),
+                new Tuple<string, string>("Effects", Properties.Settings.Default.TextureRandomizeEffects.ToString()),
+                new Tuple<string, string>("Items", Properties.Settings.Default.TextureRandomizeItems.ToString()),
+                new Tuple<string, string>("Planetary", Properties.Settings.Default.TextureRandomizePlanetary.ToString()),
+                new Tuple<string, string>("NPC", Properties.Settings.Default.TextureRandomizeNPC.ToString()),
+                new Tuple<string, string>("Player Heads", Properties.Settings.Default.TextureRandomizePlayHeads.ToString()),
+                new Tuple<string, string>("Player Bodies", Properties.Settings.Default.TextureRandomizePlayBodies.ToString()),
+                new Tuple<string, string>("Placeables", Properties.Settings.Default.TextureRandomizePlaceables.ToString()),
+                new Tuple<string, string>("Party", Properties.Settings.Default.TextureRandomizeParty.ToString()),
+                new Tuple<string, string>("Stunt", Properties.Settings.Default.TextureRandomizeStunt.ToString()),
+                new Tuple<string, string>("Vehicles", Properties.Settings.Default.TextureRandomizeVehicles.ToString()),
+                new Tuple<string, string>("Weapons", Properties.Settings.Default.TextureRandomizeWeapons.ToString()),
+                new Tuple<string, string>("Other", Properties.Settings.Default.TextureRandomizeOther.ToString()),
                 new Tuple<string, string>("", ""),  // Skip a row.
             };
 

--- a/kotor Randomizer 2/Resources/help/TextureHelp.txt
+++ b/kotor Randomizer 2/Resources/help/TextureHelp.txt
@@ -29,6 +29,8 @@ The 'Texture Packs' refer the the three quality settings (low, medium, and high)
 
 > Party - The textures used by party members.
 
+> Stunt - The textures used by STUNT (cutscene) modules.
+
 > Vehicles - Vehicle textures.
 
 > Weapons - The textures used in the 3D rendering of weapons.


### PR DESCRIPTION
Fixes #21.

- Fix timing of updating form settings from on close to immediately.
  - SoundForm
  - ItemForm
  - TextureForm
  - PathForm
- Added a method to quickly close all other windows from the StartForm (right-click menu).
- Updated ItemForm's Omitted Items feature
  - Added a reset button to go back to default settings.
  - Text box will now add when Enter is pressed.
  - Text box is cleared when an entry is added.
  - Only allows lower case.
  - Duplicate entries are not allowed.
- Added path validation before randomizing.