### PR TITLE
Initialize bound modules on startup.

### DIFF
--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -37,9 +37,6 @@
             <setting name="RandomizeBattleMusic" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="ModulesInitialized" serializeAs="String">
-                <value>False</value>
-            </setting>
             <setting name="ModulePresetSelected" serializeAs="String">
                 <value>True</value>
             </setting>
@@ -253,14 +250,20 @@
             <setting name="UseRandoRules" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="RemoveDmcaMusic" serializeAs="String">
-                <value>False</value>
-            </setting>
             <setting name="RandomizeSwoopBoosters" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="RandomizeSwoopObstacles" serializeAs="String">
                 <value>False</value>
+            </setting>
+            <setting name="RemoveDmcaMusic" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="OmittedModules" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+                </value>
             </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>

--- a/kotor Randomizer 2/Digraph.cs
+++ b/kotor Randomizer 2/Digraph.cs
@@ -253,7 +253,7 @@ namespace kotor_Randomizer_2
                 CheckReachabilityDFS(touched);
             } while (ReachableUpdated);
 
-            Console.WriteLine($"Time used to create digraph and check reachability...{sw.Elapsed}");
+            Console.WriteLine($" > Time used to create digraph and check reachability...{sw.Elapsed}");
         }
 
         /// <summary>
@@ -521,9 +521,21 @@ namespace kotor_Randomizer_2
         public bool IsGoalReachable()
         {
             bool goal = true;
-            if (GoalIsMalak) goal &= IsMalakReachable();
-            if (GoalIsPazaak) goal &= IsPazaakReachable();
-            if (GoalIsStarMap) goal &= IsStarMapReachable();
+            if (GoalIsMalak)
+            {
+                goal &= IsMalakReachable();
+                if (!goal) Console.WriteLine(" - Goal unreachable: Malak");
+            }
+            if (goal && GoalIsPazaak)
+            {
+                goal &= IsPazaakReachable();
+                if (!goal) Console.WriteLine(" - Goal unreachable: Pazaak");
+            }
+            if (goal && GoalIsStarMap)
+            {
+                goal &= IsStarMapReachable();
+                if (!goal) Console.WriteLine(" - Goal unreachable: Star Map");
+            }
             return goal;
         }
         #endregion

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -22,17 +22,6 @@ namespace kotor_Randomizer_2
             InitializeComponent();
             var settings = Properties.Settings.Default;
 
-            // Set up the bound module collection if it hasn't been already
-            if (!Properties.Settings.Default.ModulesInitialized)
-            {
-                Globals.BoundModules.Clear();
-                foreach (string s in Globals.MODULES)
-                {
-                    Globals.BoundModules.Add(new Globals.Mod_Entry(s, true));
-                }
-                Properties.Settings.Default.ModulesInitialized = true;
-            }
-
             // Set up the controls
             RandomizedListBox.DisplayMember = "name";
             OmittedListBox.DisplayMember = "name";
@@ -89,21 +78,15 @@ namespace kotor_Randomizer_2
             UpdateListBoxes();
         }
 
-        public static void static_loadPreset(string preset)
-        {
-            for (int i = 0; i < Globals.BoundModules.Count; i++)
-            {
-                Globals.BoundModules[i] = new Globals.Mod_Entry(Globals.BoundModules[i].Code, false);
-
-                if (Globals.OMIT_PRESETS[preset].Contains(Globals.BoundModules[i].Code))
-                {
-                    Globals.BoundModules[i] = new Globals.Mod_Entry(Globals.BoundModules[i].Code, true);
-                }
-            }
-        }
-
         #endregion
         #region Private Members
+
+        // Stores omitted modules
+        private void UpdateOmittedModulesSetting()
+        {
+            Properties.Settings.Default.OmittedModules.Clear();
+            Properties.Settings.Default.OmittedModules.AddRange(Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Code).ToArray());
+        }
 
         // Makes list work
         private void UpdateListBoxes()
@@ -112,6 +95,7 @@ namespace kotor_Randomizer_2
             RandomizedListBox.Update();
             OmittedListBox.DataSource = Globals.BoundModules.Where(x => x.Omitted).ToList();
             OmittedListBox.Update();
+            UpdateOmittedModulesSetting();
         }
 
         // How we load the built in presets. (May be subject to change if I change my mind about how I want User-presets to work.)

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -11,7 +11,14 @@ namespace kotor_Randomizer_2
         {
             InitializeComponent();
 
-            Properties.Settings.Default.ModulesInitialized = false; // Might need to change this
+            Properties.Settings settings = Properties.Settings.Default;
+
+            // Initialize the bound modules list.
+            Globals.BoundModules.Clear();
+            foreach (string s in Globals.MODULES)
+            {
+                Globals.BoundModules.Add(new Globals.Mod_Entry(s, settings.OmittedModules.Contains(s)));
+            }
 
             // Checks if a path is saved
             if (Properties.Settings.Default.Kotor1Path == "")
@@ -20,23 +27,23 @@ namespace kotor_Randomizer_2
             }
 
             //Active Rando Categories (start false)
-            Properties.Settings.Default.DoRandomization_Module = false;
-            Properties.Settings.Default.DoRandomization_Sound = false;
-            Properties.Settings.Default.DoRandomization_Model = false;
-            Properties.Settings.Default.DoRandomization_Item = false;
-            Properties.Settings.Default.DoRandomization_Texture = false;
-            Properties.Settings.Default.DoRandomization_TwoDA = false;
-            Properties.Settings.Default.DoRandomization_Text = false;
-            Properties.Settings.Default.DoRandomization_Other = false;
+            settings.DoRandomization_Module = false;
+            settings.DoRandomization_Sound = false;
+            settings.DoRandomization_Model = false;
+            settings.DoRandomization_Item = false;
+            settings.DoRandomization_Texture = false;
+            settings.DoRandomization_TwoDA = false;
+            settings.DoRandomization_Text = false;
+            settings.DoRandomization_Other = false;
 
-            if (File.Exists(Properties.Settings.Default.Kotor1Path + "\\RANDOMIZED.log"))
+            if (File.Exists(settings.Kotor1Path + "\\RANDOMIZED.log"))
             {
-                Properties.Settings.Default.KotorIsRandomized = true;
+                settings.KotorIsRandomized = true;
                 randomize_button.Text = "Unrandomize!";
             }
             else
             {
-                Properties.Settings.Default.KotorIsRandomized = false;
+                settings.KotorIsRandomized = false;
                 randomize_button.Text = "Randomize!";
             }
 
@@ -143,16 +150,12 @@ namespace kotor_Randomizer_2
         /// </summary>
         private void StartForm_Load(object sender, EventArgs e)
         {
-            //Randomize.GenerateSeed();
-            //Properties.Settings.Default.Seed = Randomize.Rng.Next();
-            //Properties.Settings.Default.Seed = Randomize.Seed;
             Properties.Settings.Default.Seed = Randomize.GenerateSeed();
             Randomize.RestartRng();
         }
 
         private void StartForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.ModulesInitialized = false;
             Properties.Settings.Default.Save();
         }
 

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -19,7 +19,6 @@ namespace kotor_Randomizer_2
             {
                 string versionText = new string(br.ReadChars(VERSION.Length));
 
-
                 if (versionText == VERSION)    // Version Check
                 {
                     // Category Booleans
@@ -39,21 +38,14 @@ namespace kotor_Randomizer_2
                         // Check that Module data is present
                         if (new string(br.ReadChars(4)) != "MODU") { throw new IOException("Module Randomization is Active, but no such preset data is found. Is the file corrupt?"); }
 
-                        // Initialize the BoundModules global if it hasn't been already
-                        if (!Properties.Settings.Default.ModulesInitialized)
-                        {
-                            foreach (string st in Globals.MODULES)
-                            {
-                                Globals.BoundModules.Add(new Globals.Mod_Entry(st, true));
-                            }
-                            Properties.Settings.Default.ModulesInitialized = true;
-                        }
-
                         // Pull the list of omitted modules from the save
-                        List<string> omit_mods = new List<string>();
+                        System.Collections.Specialized.StringCollection omittedMods = Properties.Settings.Default.OmittedModules;
+                        omittedMods.Clear();
+
+                        StringBuilder sb = new StringBuilder();
                         while (br.PeekChar() != '\n')
                         {
-                            StringBuilder sb = new StringBuilder();
+                            sb.Clear();
 
                             while (br.PeekChar() != '\0')
                             {
@@ -61,21 +53,17 @@ namespace kotor_Randomizer_2
                             }
                             br.ReadChar();
 
-                            omit_mods.Add(sb.ToString());
+                            omittedMods.Add(sb.ToString());
                         }
                         br.ReadChar();
 
-                        // Load the omitted preset into BoundModules
                         for (int i = 0; i < Globals.BoundModules.Count; i++)
                         {
-                            Globals.BoundModules[i] = new Globals.Mod_Entry(Globals.BoundModules[i].Code, false);
-
-                            if (omit_mods.Contains(Globals.BoundModules[i].Code))
-                            {
-                                Globals.BoundModules[i] = new Globals.Mod_Entry(Globals.BoundModules[i].Code, true);
-                            }
+                            Globals.BoundModules[i] = new Globals.Mod_Entry(
+                                Globals.BoundModules[i].Code,
+                                omittedMods.Contains(Globals.BoundModules[i].Code)
+                                );
                         }
-                        Properties.Settings.Default.ModulesInitialized = true;
 
                         // Load bool settings
                         Properties.Settings.Default.ModuleExtrasValue = 0;
@@ -91,6 +79,7 @@ namespace kotor_Randomizer_2
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.VulkarSpiceLZ; }
 
                         // Load reachability settings
+                        Properties.Settings.Default.UseRandoRules = br.ReadBoolean();
                         Properties.Settings.Default.VerifyReachability = br.ReadBoolean();
                         Properties.Settings.Default.IgnoreOnceEdges = br.ReadBoolean();
                         Properties.Settings.Default.AllowGlitchClip = br.ReadBoolean();
@@ -335,7 +324,6 @@ namespace kotor_Randomizer_2
                 {
                     bw.Write("MODU".ToCharArray());
 
-                    // FIX LATER - Possibility that BoundModules is empty if Module Form never opened.
                     foreach (Globals.Mod_Entry me in Globals.BoundModules.Where(x => x.Omitted))
                     {
                         bw.Write(me.Code.ToCharArray());
@@ -354,6 +342,16 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators));  // Fixed Leviathan Elevators
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ));    // Add Vulkar Spice Loading Zone
 
+                    bw.Write(Properties.Settings.Default.UseRandoRules);
+                    bw.Write(Properties.Settings.Default.VerifyReachability);
+                    bw.Write(Properties.Settings.Default.IgnoreOnceEdges);
+                    bw.Write(Properties.Settings.Default.AllowGlitchClip);
+                    bw.Write(Properties.Settings.Default.AllowGlitchDlz);
+                    bw.Write(Properties.Settings.Default.AllowGlitchFlu);
+                    bw.Write(Properties.Settings.Default.AllowGlitchGpw);
+                    bw.Write(Properties.Settings.Default.GoalIsMalak);
+                    bw.Write(Properties.Settings.Default.GoalIsPazaak);
+                    bw.Write(Properties.Settings.Default.GoalIsStarMaps);
                 }
                 #endregion
                 #region Items

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -133,18 +133,6 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool ModulesInitialized {
-            get {
-                return ((bool)(this["ModulesInitialized"]));
-            }
-            set {
-                this["ModulesInitialized"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool ModulePresetSelected {
             get {
@@ -984,6 +972,19 @@ namespace kotor_Randomizer_2.Properties {
             }
             set {
                 this["RemoveDmcaMusic"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
+            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />")]
+        public global::System.Collections.Specialized.StringCollection OmittedModules {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["OmittedModules"]));
+            }
+            set {
+                this["OmittedModules"] = value;
             }
         }
     }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -29,9 +29,6 @@
     <Setting Name="RandomizeBattleMusic" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="ModulesInitialized" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
     <Setting Name="ModulePresetSelected" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -245,6 +242,10 @@
     </Setting>
     <Setting Name="RemoveDmcaMusic" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="OmittedModules" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -52,22 +52,6 @@ namespace kotor_Randomizer_2
             Digraph.ResetSettings();
             LookupTable.Clear();
 
-            // Set up the bound module collection if it hasn't been already.
-            if (!Properties.Settings.Default.ModulesInitialized)
-            {
-                Globals.BoundModules.Clear();
-                foreach (string s in Globals.MODULES)
-                {
-                    Globals.BoundModules.Add(new Globals.Mod_Entry(s, true));
-                }
-                Properties.Settings.Default.ModulesInitialized = true;
-            }
-
-            //if (!Properties.Settings.Default.ModulePresetSelected)
-            //{
-            //    //Figure something out here
-            //}
-
             // Split the Bound modules into their respective lists.
             List<string> ExcludedModules = Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Code).ToList();
             List<string> IncludedModules = Globals.BoundModules.Where(x => !x.Omitted).Select(x => x.Code).ToList();
@@ -83,6 +67,8 @@ namespace kotor_Randomizer_2
                 while (!reachable && iterations < MAX_ITERATIONS)
                 {
                     iterations++;
+
+                    Console.WriteLine($"Iteration {iterations}:");
 
                     // Shuffle the list of included modules.
                     List<string> ShuffledModules = IncludedModules.ToList();
@@ -475,7 +461,7 @@ namespace kotor_Randomizer_2
                 var lookup = LookupTable[ruleKVP.Key];
                 if (ruleKVP.Value.Contains(lookup))
                 {
-                    Console.WriteLine($"Rule 1 violated: {ruleKVP.Key} replaces {lookup}");
+                    Console.WriteLine($" - Rule 1 violated: {ruleKVP.Key} replaces {lookup}");
                     return true;
                 }
             }
@@ -486,7 +472,7 @@ namespace kotor_Randomizer_2
                 var lookup = LookupTable[ruleKVP.Key];
                 if (ruleKVP.Value.Contains(lookup))
                 {
-                    Console.WriteLine($"Rule 2 violated: {ruleKVP.Key} replaces {lookup}");
+                    Console.WriteLine($" - Rule 2 violated: {ruleKVP.Key} replaces {lookup}");
                     return true;
                 }
             }
@@ -497,12 +483,12 @@ namespace kotor_Randomizer_2
                 var lookup = LookupTable[ruleKVP.Key];
                 if (ruleKVP.Value.Contains(lookup))
                 {
-                    Console.WriteLine($"Rule 3 violated: {ruleKVP.Key} replaces {lookup}");
+                    Console.WriteLine($" - Rule 3 violated: {ruleKVP.Key} replaces {lookup}");
                     return true;
                 }
             }
 
-            Console.WriteLine("No rules violated.");
+            //Console.WriteLine("No rules violated.");
             return false;
         }
 


### PR DESCRIPTION
Fixes #17.
- Initializes modules on startup using a new setting for omitted modules.
- Added missing module reachability settings to KRP write.